### PR TITLE
feat: Add rate-limited streaming example with intelligent LSN feedback throttling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -151,10 +151,46 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
 
 [[package]]
 name = "futures-io"
@@ -163,10 +199,45 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
+name = "futures-macro"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.111",
+]
+
+[[package]]
 name = "futures-sink"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
+
+[[package]]
+name = "futures-task"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f90f7dce0722e95104fcb095585910c0977252f286e354b5e3bd38902cd99988"
+
+[[package]]
+name = "futures-util"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-macro",
+ "futures-sink",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
 
 [[package]]
 name = "glob"
@@ -384,11 +455,13 @@ version = "0.2.1"
 dependencies = [
  "bytes",
  "chrono",
+ "futures",
  "libpq-sys",
  "serde",
  "serde_json",
  "thiserror",
  "tokio",
+ "tokio-stream",
  "tokio-util",
  "tracing",
  "tracing-subscriber",
@@ -399,6 +472,12 @@ name = "pin-project-lite"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
 name = "pkg-config"
@@ -562,6 +641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -654,6 +739,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.111",
+]
+
+[[package]]
+name = "tokio-stream"
+version = "0.1.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,3 +29,5 @@ default = []
 [dev-dependencies]
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.47.2", features = ["full"] }
+futures = "0.3.31"
+tokio-stream = { version = "0.1.18", features = ["time"] }

--- a/README.md
+++ b/README.md
@@ -227,14 +227,14 @@ The library provides two methods for creating replication slots:
 #### Replication Slot Options
 
 - **`temporary`** (`bool`): Create a temporary slot that is not saved to disk and is dropped on error or session end. Default: `false`
-- **`two_phase`** (`Option<bool>`): Enable two-phase commit support for logical slots. This allows the slot to receive prepared transaction events. Requires PostgreSQL 15+. Default: `None`
-- **`reserve_wal`** (`Option<bool>`): Reserve WAL immediately for physical slots. Prevents WAL files from being removed before the slot is active. Default: `None`
+- **`two_phase`** (`bool`): Enable two-phase commit support for logical slots. This allows the slot to receive prepared transaction events. Requires PostgreSQL 15+. Default: `None`
+- **`reserve_wal`** (`bool`): Reserve WAL immediately for physical slots. Prevents WAL files from being removed before the slot is active. Default: `None`
 - **`snapshot`** (`Option<String>`): Control snapshot behavior for logical slots:
   - `"export"` - Export the snapshot for use by other sessions
   - `"use"` - Use an existing snapshot
   - `"nothing"` - Don't export or use a snapshot
   - Default: `None`
-- **`failover`** (`Option<bool>`): Enable the slot for failover synchronization. When enabled, the slot will be synchronized to standby servers for high availability. Requires PostgreSQL 16+. Default: `None`
+- **`failover`** (`bool`): Enable the slot for failover synchronization. When enabled, the slot will be synchronized to standby servers for high availability. Requires PostgreSQL 16+. Default: `None`
 
 ## Message Types
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -6,12 +6,13 @@ This directory contains examples demonstrating how to use the `pg_walstream` lib
 
 ### 1. basic_streaming.rs
 
-Demonstrates the high-level Stream API for consuming WAL changes.
+Demonstrates the high-level Stream API wrapped with `futures::stream::unfold` for Stream trait compatibility.
 
 **Features:**
-- Async iterator-like interface
+- Async iterator-like interface with futures::Stream compatibility
 - Automatic event processing with retry logic
 - Comprehensive event type handling (Insert, Update, Delete, etc.)
+- Stream combinators support (filter, take_while, etc.)
 - Graceful shutdown with Ctrl+C
 
 **Run:**
@@ -19,7 +20,35 @@ Demonstrates the high-level Stream API for consuming WAL changes.
 cargo run --example basic_streaming
 ```
 
-### 2. polling_example.rs
+### 2. rate_limited_streaming.rs
+
+**NEW**: Demonstrates rate limiting and flow control using futures::Stream combinators.
+
+**Features:**
+- Rate limiting to prevent overwhelming downstream systems
+- Configurable events per second limit
+- Real-time rate statistics and monitoring
+- Backpressure handling with automatic throttling
+- Practical example of Stream trait usage
+- Protection for downstream APIs with rate limits
+
+**Run:**
+```bash
+# Default: 10 events per second
+cargo run --example rate_limited_streaming
+
+# Custom rate limit
+MAX_EVENTS_PER_SECOND=50 cargo run --example rate_limited_streaming
+```
+
+**Use Cases:**
+- Protecting downstream APIs from being overwhelmed
+- Complying with third-party service rate limits
+- Spreading load over time for cost optimization
+- Controlled batch processing
+- Testing with realistic production loads
+
+### 3. polling_example.rs
 
 Shows the lower-level polling API for manual event retrieval.
 
@@ -33,7 +62,7 @@ Shows the lower-level polling API for manual event retrieval.
 cargo run --example polling_example
 ```
 
-### 3. safe_transaction_consumer.rs
+### 4. safe_transaction_consumer.rs
 
 **NEW**: Advanced example demonstrating safe transaction processing with ordered commits.
 
@@ -57,7 +86,7 @@ cargo run --example safe_transaction_consumer
 - Implementing exactly-once processing semantics
 - Safe CDC (Change Data Capture) pipelines
 
-### 4. pg_basebackup.rs
+### 5. pg_basebackup.rs
 
 **NEW**: Complete implementation of pg_basebackup functionality for creating physical database backups.
 
@@ -154,7 +183,7 @@ host    replication     postgres        127.0.0.1/32            md5
 #### 3. Connection String
 
 ```bash
-export PGCONNSTRING="postgresql://postgres:password@localhost:5432/postgres?replication=database"
+export DATABASE_URL="postgresql://postgres:password@localhost:5432/postgres?replication=database"
 ```
 
 **Note:** Physical replication requires the `replication=database` parameter and appropriate permissions.

--- a/examples/pg_basebackup.rs
+++ b/examples/pg_basebackup.rs
@@ -30,7 +30,7 @@
 //! cargo run --example pg_basebackup
 //!
 //! # Or with custom connection string:
-//! PGCONNSTRING="postgresql://postgres:password@localhost:5432/postgres?replication=database" \
+//! DATABASE_URL="postgresql://postgres:password@localhost:5432/postgres?replication=database" \
 //!   cargo run --example pg_basebackup
 //! ```
 //!

--- a/examples/rate_limited_streaming.rs
+++ b/examples/rate_limited_streaming.rs
@@ -1,0 +1,263 @@
+//! Rate-limited PostgreSQL WAL streaming example with futures::Stream
+//!
+//! This example demonstrates how to:
+//! - Wrap EventStream with futures::stream::unfold for Stream trait compatibility
+//! - Apply rate limiting to control event processing speed
+//! - Use stream combinators for flow control
+//! - Prevent overwhelming downstream systems with too many events
+//! - Implement backpressure and throttling
+//!
+//! ## Use Cases
+//!
+//! - Protecting downstream APIs from being overwhelmed
+//! - Spreading load over time for cost optimization
+//! - Complying with rate limits of external services
+//! - Controlled batch processing
+//!
+//! ## Prerequisites
+//!
+//! 1. PostgreSQL server running (version 14+)
+//! 2. Database with logical replication enabled in postgresql.conf:
+//!    ```
+//!    wal_level = logical
+//!    max_replication_slots = 4
+//!    max_wal_senders = 4
+//!    ```
+//! 3. A publication created on the source database:
+//!    ```sql
+//!    CREATE PUBLICATION my_publication FOR ALL TABLES;
+//!    ```
+//!
+//! ## Environment Variables
+//!
+//! Set the following environment variable or modify the connection string:
+//! ```bash
+//! export DATABASE_URL="postgresql://postgres:password@localhost:5432/postgres?replication=database"
+//! ```
+//!
+//! ## Usage
+//!
+//! ```bash
+//! # Limit to 10 events per second
+//! cargo run --example rate_limited_streaming
+//! ```
+
+use futures::stream;
+use pg_walstream::{
+    CancellationToken, EventType, LogicalReplicationStream, ReplicationStreamConfig, RetryConfig,
+};
+use std::env;
+use std::time::{Duration, Instant};
+use tokio_stream::StreamExt as TokioStreamExt;
+use tracing::{error, info, warn, Level};
+use tracing_subscriber;
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Initialize logging
+    tracing_subscriber::fmt()
+        .with_max_level(Level::INFO)
+        .with_target(false)
+        .init();
+
+    info!("Starting rate-limited PostgreSQL WAL streaming example");
+
+    // Get connection string from environment or use default
+    let connection_string = env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://postgres:password@localhost:5432/postgres?replication=database".to_string()
+    });
+
+    info!("Connection string: {}", mask_password(&connection_string));
+
+    // Configure rate limiting
+    let max_events_per_second = env::var("MAX_EVENTS_PER_SECOND")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(10); // Default: 10 events/second
+
+    info!(
+        "Rate limit configured: {} events per second",
+        max_events_per_second
+    );
+
+    // Configure the replication stream
+    let config = ReplicationStreamConfig::new(
+        "rate_limited_slot".to_string(), // Replication slot name
+        "my_publication".to_string(),    // Publication name
+        2,                               // Protocol version
+        true,                            // Enable streaming
+        Duration::from_secs(10),         // Feedback interval
+        Duration::from_secs(30),         // Connection timeout
+        Duration::from_secs(60),         // Health check interval
+        RetryConfig::default(),
+    );
+
+    info!("Creating replication stream...");
+
+    // Create and initialize the stream
+    let mut stream = LogicalReplicationStream::new(&connection_string, config).await?;
+
+    info!("Stream created successfully");
+
+    // Start replication from the latest position
+    stream.start(None).await?;
+
+    info!("Replication started successfully");
+    info!("Listening for changes with rate limiting... (Press Ctrl+C to stop)");
+
+    // Create cancellation token for graceful shutdown
+    let cancel_token = CancellationToken::new();
+    let cancel_token_clone = cancel_token.clone();
+
+    // Setup Ctrl+C handler
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("Failed to listen for ctrl-c");
+        info!("Received shutdown signal, cleaning up...");
+        cancel_token_clone.cancel();
+    });
+
+    // Convert to EventStream
+    let event_stream = stream.into_stream(cancel_token);
+
+    // Wrap with futures::stream::unfold to get a proper futures::Stream
+    let pg_stream = stream::unfold(event_stream, |mut event_stream| async move {
+        match event_stream.next().await {
+            Ok(event) => {
+                // Update applied LSN after successful event retrieval
+                event_stream.update_applied_lsn(event.lsn.value());
+                Some((Ok(event), event_stream))
+            }
+            Err(e) => {
+                // Return error and stop the stream
+                Some((Err(e), event_stream))
+            }
+        }
+    });
+
+    // Apply rate limiting using stream combinator!
+    // Calculate delay between events based on desired rate
+    let delay_between_events = Duration::from_secs(1) / max_events_per_second;
+
+    info!(
+        "Applying rate limit: {} events/sec ({}ms between events)",
+        max_events_per_second,
+        delay_between_events.as_millis()
+    );
+
+    // Use tokio_stream's throttle combinator to rate limit the stream
+    let mut rate_limited_stream = Box::pin(pg_stream.throttle(delay_between_events));
+
+    // Statistics
+    let mut event_count = 0;
+    let mut insert_count = 0;
+    let mut update_count = 0;
+    let mut delete_count = 0;
+    let start_time = Instant::now();
+
+    // Process events with rate limiting applied by stream combinator
+    while let Some(result) = TokioStreamExt::next(&mut rate_limited_stream).await {
+        match result {
+            Ok(event) => {
+                event_count += 1;
+
+                // Process events by type
+                match &event.event_type {
+                    EventType::Insert { schema, table, .. } => {
+                        insert_count += 1;
+                        info!("INSERT into {}.{} at LSN {}", schema, table, event.lsn);
+                    }
+                    EventType::Update { schema, table, .. } => {
+                        update_count += 1;
+                        info!("UPDATE {}.{} at LSN {}", schema, table, event.lsn);
+                    }
+                    EventType::Delete { schema, table, .. } => {
+                        delete_count += 1;
+                        info!("DELETE from {}.{} at LSN {}", schema, table, event.lsn);
+                    }
+                    EventType::Begin {
+                        transaction_id,
+                        final_lsn,
+                        ..
+                    } => {
+                        info!("BEGIN transaction {} at LSN {}", transaction_id, final_lsn);
+                    }
+                    EventType::Commit { commit_lsn, .. } => {
+                        info!("COMMIT transaction at LSN {}", commit_lsn);
+                    }
+                    EventType::Truncate(tables) => {
+                        warn!("TRUNCATE tables: {:?}", tables);
+                    }
+                    _ => {
+                        info!("Event at LSN {}", event.lsn);
+                    }
+                }
+
+                // Show statistics every 20 events
+                if event_count % 20 == 0 {
+                    let elapsed = start_time.elapsed();
+                    let actual_rate = event_count as f64 / elapsed.as_secs_f64();
+
+                    info!(
+                        "Statistics: {} total events ({} inserts, {} updates, {} deletes) | \
+                         Actual rate: {:.1} events/sec | Target: {} events/sec",
+                        event_count,
+                        insert_count,
+                        update_count,
+                        delete_count,
+                        actual_rate,
+                        max_events_per_second
+                    );
+                }
+            }
+            Err(e) => {
+                error!("Error: {}", e);
+                break;
+            }
+        }
+    }
+
+    let total_duration = start_time.elapsed();
+    let actual_rate = event_count as f64 / total_duration.as_secs_f64();
+
+    info!(
+        "Stream ended. Final statistics:\n\
+         Total events: {}\n\
+         - Inserts: {}\n\
+         - Updates: {}\n\
+         - Deletes: {}\n\
+         Duration: {:.2}s\n\
+         Actual rate: {:.2} events/sec\n\
+         Configured limit: {} events/sec",
+        event_count,
+        insert_count,
+        update_count,
+        delete_count,
+        total_duration.as_secs_f64(),
+        actual_rate,
+        max_events_per_second
+    );
+    info!("Graceful shutdown complete");
+
+    Ok(())
+}
+
+/// Mask password in connection string for logging
+fn mask_password(conn_str: &str) -> String {
+    if let Some(proto_end) = conn_str.find("://") {
+        let proto = &conn_str[..proto_end + 3];
+        let rest = &conn_str[proto_end + 3..];
+
+        if let Some(at_pos) = rest.find('@') {
+            let credentials = &rest[..at_pos];
+            let after_at = &rest[at_pos..];
+
+            if let Some(colon_pos) = credentials.find(':') {
+                let user = &credentials[..colon_pos];
+                return format!("{}{}:****{}", proto, user, after_at);
+            }
+        }
+    }
+    conn_str.to_string()
+}

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -2,6 +2,16 @@
 //!
 //! This module provides high-level management of logical replication streams,
 //! including connection management, slot creation, and message processing.
+//!
+//! ## Async Stream API
+//!
+//! The `EventStream` and `EventStreamRef` types provide a native `.next().await` API
+//! for simple usage without requiring trait imports. This design prioritizes ergonomics
+//! and ease of use.
+//!
+//! If you need to use this with the `futures::Stream` trait for stream combinators,
+//! you can easily wrap it using `futures::stream::unfold`. See the EventStream
+//! documentation for an example.
 
 use crate::error::{ReplicationError, Result};
 use crate::lsn::SharedLsnFeedback;
@@ -940,16 +950,38 @@ impl LogicalReplicationStream {
     }
 
     /// Check if feedback should be sent and send it
+    ///
+    /// Implements intelligent throttling: only sends feedback if the configured
+    /// interval has elapsed AND the LSN values have actually changed. This avoids
+    /// unnecessary status updates and reduces network overhead.
     #[inline]
     pub fn maybe_send_feedback(&mut self) {
-        if self
+        // Check if enough time has elapsed
+        if !self
             .state
             .should_send_feedback(self.config.feedback_interval)
         {
-            self.send_feedback().unwrap_or_else(|e| {
+            return;
+        }
+
+        // Get current LSN values that would be sent
+        let (f, a) = self.shared_lsn_feedback.get_feedback_lsn();
+        let flushed_lsn = if f > 0 {
+            f.min(self.state.last_received_lsn)
+        } else {
+            0
+        };
+        let applied_lsn = if a > 0 {
+            a.min(self.state.last_received_lsn)
+        } else {
+            0
+        };
+
+        // Only send feedback if LSN values have changed
+        if self.state.lsn_has_changed(flushed_lsn, applied_lsn) {
+            if let Err(e) = self.send_feedback() {
                 warn!("Failed to send feedback: {}", e);
-            });
-            self.state.mark_feedback_sent();
+            }
         }
     }
 
@@ -963,6 +995,9 @@ impl LogicalReplicationStream {
     /// If a shared LSN feedback tracker is configured, it will use the flushed/applied
     /// values from there (updated by the consumer). Otherwise, it falls back to the
     /// local state values.
+    ///
+    /// The method tracks the last sent LSN values to enable intelligent throttling
+    /// and avoid sending redundant status updates.
     pub fn send_feedback(&mut self) -> Result<()> {
         if self.state.last_received_lsn == 0 {
             return Ok(());
@@ -970,20 +1005,14 @@ impl LogicalReplicationStream {
 
         // This allows the consumer to update these values after committing to destination
         let (f, a) = self.shared_lsn_feedback.get_feedback_lsn();
-        // If shared feedback has values, use them; otherwise fall back to received LSN
-        let flushed_lsn = if f > 0 && f <= self.state.last_received_lsn {
-            f
-        } else if f > self.state.last_received_lsn {
-            // Consumer is ahead - this shouldn't happen but handle gracefully
-            self.state.last_received_lsn
+        // Cap LSN values to last_received_lsn (consumer shouldn't be ahead, but handle gracefully)
+        let flushed_lsn = if f > 0 {
+            f.min(self.state.last_received_lsn)
         } else {
-            // No consumer updates yet, use 0 to indicate nothing flushed/applied
             0
         };
-        let applied_lsn = if a > 0 && a <= self.state.last_received_lsn {
-            a
-        } else if a > self.state.last_received_lsn {
-            self.state.last_received_lsn
+        let applied_lsn = if a > 0 {
+            a.min(self.state.last_received_lsn)
         } else {
             0
         };
@@ -1002,6 +1031,10 @@ impl LogicalReplicationStream {
             applied_lsn,
             false, // Don't request reply
         )?;
+
+        // Record the LSN values we sent for intelligent throttling
+        self.state
+            .mark_feedback_sent_with_lsn(flushed_lsn, applied_lsn);
 
         debug!(
             "Sent feedback: received={}, flushed={}, applied={}",
@@ -1203,6 +1236,105 @@ impl LogicalReplicationStream {
 /// Create an `EventStream` by calling `into_stream()` on `LogicalReplicationStream`.
 ///
 /// # Example
+///
+/// ```no_run
+/// use pg_walstream::{LogicalReplicationStream, ReplicationStreamConfig, RetryConfig};
+/// use tokio_util::sync::CancellationToken;
+/// use std::time::Duration;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let config = ReplicationStreamConfig::new(
+///     "my_slot".to_string(),
+///     "my_publication".to_string(),
+///     2, true,
+///     Duration::from_secs(10),
+///     Duration::from_secs(30),
+///     Duration::from_secs(60),
+///     RetryConfig::default(),
+/// );
+///
+/// let mut stream = LogicalReplicationStream::new("connection_string", config).await?;
+/// stream.start(None).await?;
+///
+/// let cancel_token = CancellationToken::new();
+/// let mut event_stream = stream.into_stream(cancel_token);
+///
+/// // No need to import futures::StreamExt!
+/// loop {
+///     match event_stream.next().await {
+///         Ok(event) => {
+///             // Process event
+///             println!("Received: {:?}", event);
+///         }
+///         Err(e) if matches!(e, pg_walstream::ReplicationError::Cancelled(_)) => {
+///             // Graceful shutdown
+///             println!("Stream cancelled");
+///             break;
+///         }
+///         Err(e) => {
+///             // Handle error
+///             eprintln!("Error: {}", e);
+///             break;
+///         }
+///     }
+/// }
+/// # Ok(())
+/// # }
+/// ```
+/// Async stream of PostgreSQL replication events (owned version)
+///
+/// This struct provides an iterator-like interface for consuming replication events.
+/// It has a built-in `next()` method that returns `Future<Result<ChangeEvent>>`,
+/// allowing you to call `.next().await` without importing any traits.
+///
+/// Create an `EventStream` by calling `into_stream()` on `LogicalReplicationStream`.
+///
+/// # Using with `futures::Stream`
+///
+/// If you need to use stream combinators from the `futures` crate, you can easily
+/// wrap this with `futures::stream::unfold`:
+///
+/// ```no_run
+/// use pg_walstream::{LogicalReplicationStream, ReplicationStreamConfig, RetryConfig};
+/// use tokio_util::sync::CancellationToken;
+/// use futures::stream::{self, StreamExt};
+/// use std::time::Duration;
+///
+/// # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+/// let config = ReplicationStreamConfig::new(
+///     "my_slot".to_string(),
+///     "my_publication".to_string(),
+///     2, true,
+///     Duration::from_secs(10),
+///     Duration::from_secs(30),
+///     Duration::from_secs(60),
+///     RetryConfig::default(),
+/// );
+///
+/// let stream = LogicalReplicationStream::new("connection_string", config).await?;
+/// let cancel_token = CancellationToken::new();
+/// let event_stream = stream.into_stream(cancel_token);
+///
+/// // Wrap with unfold to get a futures::Stream
+/// let pg_stream = stream::unfold(event_stream, |mut event_stream| async move {
+///     match event_stream.next().await {
+///         Ok(event) => Some((event, event_stream)),
+///         Err(_) => None,
+///     }
+/// });
+///
+/// // Pin the stream so we can poll it
+/// let mut stream = Box::pin(pg_stream);
+///
+/// // Now you can use stream combinators!
+/// while let Some(event) = stream.next().await {
+///     println!("Event: {:?}", event);
+/// }
+/// # Ok(())
+/// # }
+/// ```
+///
+/// # Basic Example
 ///
 /// ```no_run
 /// use pg_walstream::{LogicalReplicationStream, ReplicationStreamConfig, RetryConfig};

--- a/src/types.rs
+++ b/src/types.rs
@@ -280,7 +280,7 @@ impl std::fmt::Display for SlotType {
 }
 
 /// Options for creating a replication slot
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct ReplicationSlotOptions {
     /// Create a temporary slot (not saved to disk, dropped on error or session end)
     pub temporary: bool,
@@ -296,18 +296,6 @@ pub struct ReplicationSlotOptions {
 
     /// Enable slot for failover synchronization (logical slots only)
     pub failover: bool,
-}
-
-impl Default for ReplicationSlotOptions {
-    fn default() -> Self {
-        Self {
-            temporary: false,
-            two_phase: false,
-            reserve_wal: false,
-            snapshot: None,
-            failover: false,
-        }
-    }
 }
 
 /// Options for BASE_BACKUP command


### PR DESCRIPTION

- Add new rate_limited_streaming.rs example demonstrating rate limiting with tokio_stream
- Implement intelligent LSN feedback throttling to avoid redundant status updates
- Add futures::Stream compatibility via stream::unfold wrapper pattern
- Add tokio-stream and futures dependencies to Cargo.toml
- Update documentation and examples README with rate limiting use cases
- Improve EventStream docs with futures::Stream integration examples
- Add LSN change tracking in ReplicationState to enable smart feedback
- Fix typos in README for replication slot options
- Standardize DATABASE_URL environment variable across all examples

The doctest example for using EventStream with futures::Stream was failing because the stream needs to be pinned before calling .next().await. Added Box::pin() to properly pin the stream and make the example work correctly. The logic remains identical: if the LSN value is greater than 0, it caps it to last_received_lsn using min(); otherwise, it rturns 0. Simplify feedback check logic in ReplicationState