### PR TITLE
feat: add logical replication protocol v2+ support and refactor pg_basebackup

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,12 @@
 version = 4
 
 [[package]]
+name = "adler2"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
 name = "aho-corasick"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -129,6 +135,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "crc32fast"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -149,6 +164,16 @@ name = "find-msvc-tools"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+
+[[package]]
+name = "flate2"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b375d6465b98090a5f25b1c7703f3859783755aa9a80433b36e0379a3ec2f369"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
+]
 
 [[package]]
 name = "futures"
@@ -376,6 +401,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +490,7 @@ version = "0.3.0"
 dependencies = [
  "bytes",
  "chrono",
+ "flate2",
  "futures",
  "libpq-sys",
  "serde",
@@ -639,6 +675,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "slab"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 tokio = { version = "1.47.2", features = ["full"] }
 futures = "0.3.31"
 tokio-stream = { version = "0.1.18", features = ["time"] }
+flate2 = "1.1.8"

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The Stream API provides an ergonomic, iterator-like interface:
 
 ```rust
 use pg_walstream::{
-    LogicalReplicationStream, ReplicationStreamConfig, RetryConfig,
+    LogicalReplicationStream, ReplicationStreamConfig, RetryConfig, StreamingMode,
     SharedLsnFeedback, CancellationToken,
 };
 use std::sync::Arc;
@@ -67,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "my_slot".to_string(),           // Replication slot name
         "my_publication".to_string(),     // Publication name
         2,                                // Protocol version
-        true,                             // Enable streaming
+        StreamingMode::On,                // Streaming mode
         Duration::from_secs(10),          // Feedback interval
         Duration::from_secs(30),          // Connection timeout
         Duration::from_secs(60),          // Health check interval
@@ -117,7 +117,7 @@ For more control, you can use the traditional polling approach:
 
 ```rust
 use pg_walstream::{
-    LogicalReplicationStream, ReplicationStreamConfig, RetryConfig,
+    LogicalReplicationStream, ReplicationStreamConfig, RetryConfig, StreamingMode,
     SharedLsnFeedback, CancellationToken,
 };
 use std::sync::Arc;
@@ -128,7 +128,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let config = ReplicationStreamConfig::new(
         "my_slot".to_string(),
         "my_publication".to_string(),
-        2, true,
+        2, StreamingMode::On,
         Duration::from_secs(10),
         Duration::from_secs(30),
         Duration::from_secs(60),

--- a/examples/basic_streaming.rs
+++ b/examples/basic_streaming.rs
@@ -38,6 +38,7 @@
 use futures::stream::{self, StreamExt};
 use pg_walstream::{
     CancellationToken, LogicalReplicationStream, ReplicationStreamConfig, RetryConfig,
+    StreamingMode,
 };
 use std::env;
 use std::time::Duration;
@@ -66,7 +67,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "example_slot".to_string(),   // Replication slot name
         "my_publication".to_string(), // Publication name (must exist)
         2,                            // Protocol version (2 supports streaming)
-        true,                         // Enable streaming of large transactions
+        StreamingMode::On,            // Streaming mode
         Duration::from_secs(10),      // Send feedback every 10 seconds
         Duration::from_secs(30),      // Connection timeout
         Duration::from_secs(60),      // Health check interval

--- a/examples/polling_example.rs
+++ b/examples/polling_example.rs
@@ -32,6 +32,7 @@
 
 use pg_walstream::{
     CancellationToken, LogicalReplicationStream, ReplicationStreamConfig, RetryConfig,
+    StreamingMode,
 };
 use std::env;
 use std::time::Duration;
@@ -60,7 +61,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "polling_slot".to_string(),   // Replication slot name
         "my_publication".to_string(), // Publication name (must exist)
         2,                            // Protocol version
-        true,                         // Enable streaming
+        StreamingMode::On,            // Streaming mode
         Duration::from_secs(10),      // Feedback interval
         Duration::from_secs(30),      // Connection timeout
         Duration::from_secs(60),      // Health check interval

--- a/examples/rate_limited_streaming.rs
+++ b/examples/rate_limited_streaming.rs
@@ -45,6 +45,7 @@
 use futures::stream;
 use pg_walstream::{
     CancellationToken, EventType, LogicalReplicationStream, ReplicationStreamConfig, RetryConfig,
+    StreamingMode,
 };
 use std::env;
 use std::time::{Duration, Instant};
@@ -85,7 +86,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "rate_limited_slot".to_string(), // Replication slot name
         "my_publication".to_string(),    // Publication name
         2,                               // Protocol version
-        true,                            // Enable streaming
+        StreamingMode::On,               // Streaming mode
         Duration::from_secs(10),         // Feedback interval
         Duration::from_secs(30),         // Connection timeout
         Duration::from_secs(60),         // Health check interval

--- a/examples/safe_transaction_consumer.rs
+++ b/examples/safe_transaction_consumer.rs
@@ -37,7 +37,7 @@
 
 use pg_walstream::{
     CancellationToken, ChangeEvent, EventType, LogicalReplicationStream, Lsn,
-    ReplicationStreamConfig, RetryConfig, SharedLsnFeedback,
+    ReplicationStreamConfig, RetryConfig, SharedLsnFeedback, StreamingMode,
 };
 use std::collections::BTreeMap;
 use std::env;
@@ -266,7 +266,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         "safe_consumer_slot".to_string(), // Replication slot name
         "my_publication".to_string(),     // Publication name (must exist)
         2,                                // Protocol version (2 supports streaming)
-        true,                             // Enable streaming of large transactions
+        StreamingMode::On,                // Streaming mode
         Duration::from_secs(10),          // Send feedback every 10 seconds
         Duration::from_secs(30),          // Connection timeout
         Duration::from_secs(60),          // Health check interval

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,10 @@ pub use protocol::{
 };
 
 // Re-export stream types
-pub use stream::{EventStream, EventStreamRef, LogicalReplicationStream, ReplicationStreamConfig};
+pub use stream::{
+    EventStream, EventStreamRef, LogicalReplicationStream, OriginFilter, ReplicationStreamConfig,
+    StreamingMode,
+};
 
 // Re-export tokio_util for CancellationToken
 pub use tokio_util::sync::CancellationToken;

--- a/src/types.rs
+++ b/src/types.rs
@@ -379,17 +379,7 @@ impl std::str::FromStr for Lsn {
     type Err = ReplicationError;
 
     fn from_str(s: &str) -> Result<Self> {
-        let parts: Vec<&str> = s.split('/').collect();
-        if parts.len() != 2 {
-            return Err(ReplicationError::protocol("Invalid LSN format"));
-        }
-
-        let high = u64::from_str_radix(parts[0], 16)
-            .map_err(|_| ReplicationError::protocol("Invalid LSN high part"))?;
-        let low = u64::from_str_radix(parts[1], 16)
-            .map_err(|_| ReplicationError::protocol("Invalid LSN low part"))?;
-
-        Ok(Self((high << 32) | low))
+        parse_lsn(s).map(Self)
     }
 }
 


### PR DESCRIPTION
- Add support for logical replication protocol versions 2-4
  * Streaming mode support (off/on/parallel) for in-progress transactions
  * Two-phase commit decoding (protocol v3+)
  * Parallel streaming mode (protocol v4+)
  * Logical replication messages (pg_logical_emit_message)
  * Binary mode for pgoutput
  * Origin filtering (none/any)

- Enhance ReplicationStreamConfig with builder pattern methods:
  * with_messages() for logical replication messages
  * with_binary() for binary mode
  * with_two_phase() for two-phase commit
  * with_origin() for origin filtering
  * with_streaming_mode() for dynamic streaming configuration

- Add protocol version validation to prevent misconfigurations
- Add StreamingMode enum (Off/On/Parallel) with proper validation
- Add OriginFilter enum (None/Any) for replication origin filtering

- Refactor pg_basebackup example for improved maintainability:
  * Better error handling and logging
  * Cleaner code organization
  * Enhanced tar extraction logic
  * Improved backup flow structure
