### PR TITLE
Add integration tests for rate-limited streaming, safe transaction consumer, and snapshot export workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,3 +128,87 @@ jobs:
         files: lcov.info
         fail_ci_if_error: false
         token: ${{ secrets.CODECOV_TOKEN }}
+
+  integration:
+    name: Integration Tests
+    runs-on: ubuntu-latest
+    needs: test
+
+    services:
+      postgres:
+        image: postgres:16
+        env:
+          POSTGRES_USER: postgres
+          POSTGRES_PASSWORD: postgres
+          POSTGRES_DB: test_walstream
+        ports:
+          - 5432:5432
+        options: >-
+          --health-cmd "pg_isready -U postgres"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+
+    - name: Install dependencies
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libpq-dev pkg-config libssl-dev
+
+    - name: Cache cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-integration-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-integration-
+
+    - name: Configure PostgreSQL for logical replication
+      env:
+        PGPASSWORD: postgres
+      run: |
+        psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET wal_level = 'logical';"
+        psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET max_replication_slots = 16;"
+        psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET max_wal_senders = 16;"
+        # Restart PostgreSQL container to apply wal_level change (requires restart)
+        docker restart ${{ job.services.postgres.id }}
+        # Wait for PostgreSQL to be ready after restart
+        for i in $(seq 1 30); do
+          pg_isready -h localhost -p 5432 -U postgres && break
+          echo "Waiting for PostgreSQL after restart... ($i/30)"
+          sleep 2
+        done
+
+    - name: Verify PostgreSQL logical replication config
+      env:
+        PGPASSWORD: postgres
+      run: |
+        psql -h localhost -U postgres -d test_walstream -c "SHOW wal_level;"
+        psql -h localhost -U postgres -d test_walstream -c "SHOW max_replication_slots;"
+        psql -h localhost -U postgres -d test_walstream -c "SHOW max_wal_senders;"
+
+    - name: Run integration tests
+      env:
+        DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+        DATABASE_URL_REGULAR: "postgresql://postgres:postgres@localhost:5432/test_walstream"
+        RUST_BACKTRACE: 1
+      run: |
+        cargo test --test snapshot_export -- --ignored --nocapture --test-threads=1
+
+        # Clean up any lingering replication slots between test suites
+        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
+          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+
+        cargo test --test rate_limited_streaming -- --ignored --nocapture --test-threads=1
+
+        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
+          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+
+        cargo test --test safe_transaction_consumer -- --ignored --nocapture --test-threads=1

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,18 @@ default = []
 tokio = { version = "1.47.2", features = ["full"] }
 criterion = { version = "0.8.2", features = ["html_reports"] }
 
+[[test]]
+name = "snapshot_export"
+path = "integration-tests/snapshot_export.rs"
+
+[[test]]
+name = "rate_limited_streaming"
+path = "integration-tests/rate_limited_streaming.rs"
+
+[[test]]
+name = "safe_transaction_consumer"
+path = "integration-tests/safe_transaction_consumer.rs"
+
 [[bench]]
 name = "rowdata_vs_hashmap"
 harness = false

--- a/examples/basic-streaming/src/main.rs
+++ b/examples/basic-streaming/src/main.rs
@@ -44,6 +44,7 @@ use std::env;
 use std::time::Duration;
 use tracing::{error, info, Level};
 use tracing_subscriber;
+use pg_walstream::ReplicationSlotOptions;
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -72,15 +73,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Duration::from_secs(30),      // Connection timeout
         Duration::from_secs(60),      // Health check interval
         RetryConfig::default(),       // Use default retry strategy
-    );
+    ).with_slot_options(ReplicationSlotOptions {
+        temporary: true,
+        snapshot: Some("export".to_string()),
+        ..Default::default()
+    });
 
     info!("Creating replication stream...");
 
     // Create and initialize the stream
     let mut stream = LogicalReplicationStream::new(&connection_string, config).await?;
-
+    stream.ensure_replication_slot().await?;
     info!("Stream created successfully");
-
+    if let Some(snapshot_name) = stream.exported_snapshot_name() {
+        info!("Exported snapshot: {snapshot_name}");
+    }
     // Start replication from the latest position (None = latest)
     stream.start(None).await?;
 

--- a/integration-tests/rate_limited_streaming.rs
+++ b/integration-tests/rate_limited_streaming.rs
@@ -1,0 +1,400 @@
+//! Integration tests for the rate-limited streaming pattern.
+//!
+//! These tests verify that the `into_stream()` / `EventStream` API works
+//! correctly for rate-limited event processing, matching the pattern
+//! demonstrated in `examples/rate-limited-streaming`.
+//!
+//! ## Tested Patterns
+//!
+//! - `LogicalReplicationStream::into_stream()` → `EventStream`
+//! - `EventStream::next()` for receiving events
+//! - `EventStream::update_applied_lsn()` for feedback
+//! - Rate-controlled event processing with timing between events
+//! - Event type categorization (Insert, Update, Delete, Begin, Commit)
+//!
+//! ## Prerequisites
+//!
+//! Same as `snapshot_export.rs` — requires a live PostgreSQL instance
+//! with `wal_level = logical`.
+
+use pg_walstream::{
+    CancellationToken, EventType, LogicalReplicationStream, PgReplicationConnection,
+    ReplicationSlotOptions, ReplicationStreamConfig, RetryConfig, StreamingMode,
+};
+use std::time::{Duration, Instant};
+
+fn replication_conn_string() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+            .to_string()
+    })
+}
+
+fn regular_conn_string() -> String {
+    std::env::var("DATABASE_URL_REGULAR").unwrap_or_else(|_| {
+        let repl = replication_conn_string();
+        repl.replace("?replication=database", "")
+            .replace("&replication=database", "")
+    })
+}
+
+fn setup_rate_schema(conn: &PgReplicationConnection) {
+    let _ = conn.exec(
+        "CREATE TABLE IF NOT EXISTS rate_test (id SERIAL PRIMARY KEY, payload TEXT NOT NULL)",
+    );
+    let _ = conn.exec("TRUNCATE rate_test RESTART IDENTITY");
+    let _ = conn.exec("DROP PUBLICATION IF EXISTS rate_pub");
+    let _ = conn.exec("CREATE PUBLICATION rate_pub FOR TABLE rate_test");
+}
+
+fn drop_slot(slot_name: &str) {
+    if let Ok(conn) = PgReplicationConnection::connect(&replication_conn_string()) {
+        let _ = conn.exec(&format!(
+            "SELECT pg_drop_replication_slot('{slot_name}') \
+             WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{slot_name}')"
+        ));
+    }
+}
+
+fn rate_config(slot_name: &str) -> ReplicationStreamConfig {
+    ReplicationStreamConfig::new(
+        slot_name.to_string(),
+        "rate_pub".to_string(),
+        2,
+        StreamingMode::On,
+        Duration::from_secs(10),
+        Duration::from_secs(30),
+        Duration::from_secs(60),
+        RetryConfig::default(),
+    )
+    .with_slot_options(ReplicationSlotOptions {
+        temporary: true,
+        ..Default::default()
+    })
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+/// Verify that `into_stream()` produces an `EventStream` that can receive
+/// events via `next()` — the core API used by the rate-limited example.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_event_stream_receives_events() {
+    let slot = "it_rate_basic";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_rate_schema(&regular);
+
+    let config = rate_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+
+    // Auto-cancel after 10 seconds
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        cancel_clone.cancel();
+    });
+
+    // Convert to EventStream (consumes LogicalReplicationStream)
+    let mut event_stream = stream.into_stream(cancel_token);
+
+    // Insert data to produce events
+    regular
+        .exec("INSERT INTO rate_test (payload) VALUES ('event_1'), ('event_2'), ('event_3')")
+        .expect("INSERT");
+
+    // Read events through EventStream::next()
+    let mut event_count = 0u32;
+    let mut saw_begin = false;
+    let mut saw_insert = false;
+    let mut saw_commit = false;
+
+    loop {
+        match event_stream.next().await {
+            Ok(event) => {
+                event_count += 1;
+                event_stream.update_applied_lsn(event.lsn.value());
+
+                match &event.event_type {
+                    EventType::Begin { .. } => saw_begin = true,
+                    EventType::Insert { table, .. } => {
+                        assert_eq!(&**table, "rate_test");
+                        saw_insert = true;
+                    }
+                    EventType::Commit { .. } => {
+                        saw_commit = true;
+                        // After commit, we have a full transaction — done
+                        break;
+                    }
+                    _ => {}
+                }
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => break,
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+
+    assert!(saw_begin, "expected a Begin event");
+    assert!(saw_insert, "expected at least one Insert event");
+    assert!(saw_commit, "expected a Commit event");
+    assert!(
+        event_count >= 3,
+        "expected at least 3 events (begin+insert+commit), got {event_count}"
+    );
+    println!("EventStream received {event_count} events with correct transaction boundaries");
+}
+
+/// Verify that `update_applied_lsn()` on EventStream correctly propagates
+/// feedback, matching the pattern in the rate-limited example.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_event_stream_lsn_feedback() {
+    let slot = "it_rate_feedback";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_rate_schema(&regular);
+
+    let config = rate_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        cancel_clone.cancel();
+    });
+
+    let mut event_stream = stream.into_stream(cancel_token);
+
+    // Check initial feedback state
+    let (initial_flushed, initial_applied) = event_stream.get_feedback_lsn();
+    println!("Initial feedback: flushed={initial_flushed}, applied={initial_applied}");
+
+    // Insert data
+    regular
+        .exec("INSERT INTO rate_test (payload) VALUES ('feedback_test')")
+        .expect("INSERT");
+
+    // Read until commit, updating both flushed and applied LSN
+    let mut last_lsn: u64;
+    loop {
+        match event_stream.next().await {
+            Ok(event) => {
+                last_lsn = event.lsn.value();
+                event_stream.update_flushed_lsn(last_lsn);
+                event_stream.update_applied_lsn(last_lsn);
+
+                if matches!(event.event_type, EventType::Commit { .. }) {
+                    break;
+                }
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => break,
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+
+    // Verify feedback was updated
+    let (final_flushed, final_applied) = event_stream.get_feedback_lsn();
+    assert!(
+        final_applied > 0,
+        "applied LSN should be > 0 after updating, got {final_applied}"
+    );
+    assert!(
+        final_flushed > 0,
+        "flushed LSN should be > 0 after updating, got {final_flushed}"
+    );
+    println!("Feedback updated: flushed={final_flushed}, applied={final_applied}");
+}
+
+/// Simulate rate-limited processing: add a deliberate delay between events
+/// and verify that the total processing time reflects the throttle.
+/// This mirrors the `tokio_stream::throttle` pattern from the example.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_rate_limited_event_processing() {
+    let slot = "it_rate_throttle";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_rate_schema(&regular);
+
+    let config = rate_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(15)).await;
+        cancel_clone.cancel();
+    });
+
+    let mut event_stream = stream.into_stream(cancel_token);
+
+    // Insert 5 rows to produce events
+    for i in 1..=5 {
+        regular
+            .exec(&format!(
+                "INSERT INTO rate_test (payload) VALUES ('batch_{i}')"
+            ))
+            .expect("INSERT");
+    }
+
+    // Process events with a rate limit of ~10 events/sec (100ms delay)
+    let delay_per_event = Duration::from_millis(100);
+    let start_time = Instant::now();
+    let mut event_count = 0u32;
+    let mut commit_count = 0u32;
+
+    loop {
+        match event_stream.next().await {
+            Ok(event) => {
+                event_count += 1;
+                event_stream.update_applied_lsn(event.lsn.value());
+
+                if matches!(event.event_type, EventType::Commit { .. }) {
+                    commit_count += 1;
+                }
+
+                // Apply rate limiting (like tokio_stream::throttle)
+                tokio::time::sleep(delay_per_event).await;
+
+                // After receiving all 5 commits, stop
+                if commit_count >= 5 {
+                    break;
+                }
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => break,
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+
+    let elapsed = start_time.elapsed();
+    let actual_rate = event_count as f64 / elapsed.as_secs_f64();
+
+    println!(
+        "Rate-limited processing: {event_count} events in {:.2}s ({actual_rate:.1} events/sec)",
+        elapsed.as_secs_f64()
+    );
+
+    // With 100ms delay per event and at least a few events, total time should
+    // be significantly more than 0ms
+    assert!(
+        elapsed > Duration::from_millis(200),
+        "Rate limiting should slow down processing; elapsed: {:?}",
+        elapsed
+    );
+    assert!(
+        commit_count >= 1,
+        "expected at least 1 commit, got {commit_count}"
+    );
+}
+
+/// Verify event type categorization: the example tracks insert/update/delete
+/// counts. This test verifies those event types arrive for different operations.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_event_type_categorization() {
+    let slot = "it_rate_categories";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_rate_schema(&regular);
+
+    let config = rate_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        cancel_clone.cancel();
+    });
+
+    let mut event_stream = stream.into_stream(cancel_token);
+
+    // Perform insert, update, delete — each in its own transaction
+    regular
+        .exec("INSERT INTO rate_test (payload) VALUES ('to_update'), ('to_delete')")
+        .expect("INSERT");
+    // Need to set replica identity to FULL for UPDATE/DELETE to show old tuple data
+    let _ = regular.exec("ALTER TABLE rate_test REPLICA IDENTITY FULL");
+    regular
+        .exec("UPDATE rate_test SET payload = 'updated' WHERE payload = 'to_update'")
+        .expect("UPDATE");
+    regular
+        .exec("DELETE FROM rate_test WHERE payload = 'to_delete'")
+        .expect("DELETE");
+
+    let mut insert_count = 0u32;
+    let mut update_count = 0u32;
+    let mut delete_count = 0u32;
+    let mut commit_count = 0u32;
+
+    loop {
+        match event_stream.next().await {
+            Ok(event) => {
+                event_stream.update_applied_lsn(event.lsn.value());
+
+                match &event.event_type {
+                    EventType::Insert { table, .. } => {
+                        assert_eq!(&**table, "rate_test");
+                        insert_count += 1;
+                    }
+                    EventType::Update { table, .. } => {
+                        assert_eq!(&**table, "rate_test");
+                        update_count += 1;
+                    }
+                    EventType::Delete { table, .. } => {
+                        assert_eq!(&**table, "rate_test");
+                        delete_count += 1;
+                    }
+                    EventType::Commit { .. } => {
+                        commit_count += 1;
+                    }
+                    _ => {}
+                }
+
+                // We expect 3 transactions: INSERT (2 rows), UPDATE (1 row), DELETE (1 row)
+                if commit_count >= 3 {
+                    break;
+                }
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => break,
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+
+    assert!(
+        insert_count >= 2,
+        "expected >=2 inserts, got {insert_count}"
+    );
+    assert!(update_count >= 1, "expected >=1 update, got {update_count}");
+    assert!(delete_count >= 1, "expected >=1 delete, got {delete_count}");
+    println!(
+        "Event categorization: {insert_count} inserts, {update_count} updates, {delete_count} deletes"
+    );
+}

--- a/integration-tests/safe_transaction_consumer.rs
+++ b/integration-tests/safe_transaction_consumer.rs
@@ -1,0 +1,547 @@
+//! Integration tests for the safe transaction consumer pattern.
+//!
+//! These tests verify the transaction-buffered consumption pattern
+//! demonstrated in `examples/safe-transaction-consumer`:
+//!
+//! - Transaction boundaries (Begin → data changes → Commit)
+//! - Buffering changes per transaction until commit
+//! - Ordered commit processing
+//! - LSN feedback only after successful commit application
+//! - Graceful shutdown with cancellation
+//!
+//! ## Prerequisites
+//!
+//! Same as `snapshot_export.rs` — requires a live PostgreSQL instance
+//! with `wal_level = logical`.
+
+use pg_walstream::{
+    CancellationToken, ChangeEvent, EventType, LogicalReplicationStream, Lsn,
+    PgReplicationConnection, ReplicationSlotOptions, ReplicationStreamConfig, RetryConfig,
+    SharedLsnFeedback, StreamingMode,
+};
+use std::collections::BTreeMap;
+use std::sync::Arc;
+use std::time::Duration;
+
+fn replication_conn_string() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+            .to_string()
+    })
+}
+
+fn regular_conn_string() -> String {
+    std::env::var("DATABASE_URL_REGULAR").unwrap_or_else(|_| {
+        let repl = replication_conn_string();
+        repl.replace("?replication=database", "")
+            .replace("&replication=database", "")
+    })
+}
+
+fn setup_safe_schema(conn: &PgReplicationConnection) {
+    let _ = conn.exec(
+        "CREATE TABLE IF NOT EXISTS safe_test (\
+         id SERIAL PRIMARY KEY, \
+         name TEXT NOT NULL, \
+         value INT NOT NULL DEFAULT 0\
+         )",
+    );
+    let _ = conn.exec("TRUNCATE safe_test RESTART IDENTITY");
+    let _ = conn.exec("ALTER TABLE safe_test REPLICA IDENTITY FULL");
+    let _ = conn.exec("DROP PUBLICATION IF EXISTS safe_pub");
+    let _ = conn.exec("CREATE PUBLICATION safe_pub FOR TABLE safe_test");
+}
+
+fn drop_slot(slot_name: &str) {
+    if let Ok(conn) = PgReplicationConnection::connect(&replication_conn_string()) {
+        let _ = conn.exec(&format!(
+            "SELECT pg_drop_replication_slot('{slot_name}') \
+             WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{slot_name}')"
+        ));
+    }
+}
+
+fn safe_config(slot_name: &str) -> ReplicationStreamConfig {
+    ReplicationStreamConfig::new(
+        slot_name.to_string(),
+        "safe_pub".to_string(),
+        2,
+        StreamingMode::On,
+        Duration::from_secs(10),
+        Duration::from_secs(30),
+        Duration::from_secs(60),
+        RetryConfig::default(),
+    )
+    .with_slot_options(ReplicationSlotOptions {
+        temporary: true,
+        ..Default::default()
+    })
+}
+
+// ─── Minimal transaction buffer (mirrors the example's SafeReplicationConsumer) ─
+
+struct TxBuffer {
+    xid: u32,
+    changes: Vec<ChangeEvent>,
+    commit_lsn: Option<Lsn>,
+}
+
+struct TestConsumer {
+    feedback: Arc<SharedLsnFeedback>,
+    active_transactions: BTreeMap<u32, TxBuffer>,
+    committed_xids: Vec<u32>,
+    last_applied_lsn: u64,
+}
+
+impl TestConsumer {
+    fn new(feedback: Arc<SharedLsnFeedback>) -> Self {
+        Self {
+            feedback,
+            active_transactions: BTreeMap::new(),
+            committed_xids: Vec::new(),
+            last_applied_lsn: 0,
+        }
+    }
+
+    fn process_event(&mut self, event: ChangeEvent) {
+        match &event.event_type {
+            EventType::Begin { transaction_id, .. } => {
+                self.active_transactions.insert(
+                    *transaction_id,
+                    TxBuffer {
+                        xid: *transaction_id,
+                        changes: Vec::new(),
+                        commit_lsn: None,
+                    },
+                );
+            }
+            EventType::Insert { .. } | EventType::Update { .. } | EventType::Delete { .. } => {
+                // Buffer the change in the most recent active transaction
+                if let Some(tx) = self.active_transactions.values_mut().last() {
+                    tx.changes.push(event);
+                }
+            }
+            EventType::Commit { commit_lsn, .. } => {
+                let xid_opt = self.active_transactions.keys().next().copied();
+                if let Some(xid) = xid_opt {
+                    if let Some(mut tx) = self.active_transactions.remove(&xid) {
+                        tx.commit_lsn = Some(*commit_lsn);
+                        // Apply (in a real system this would write to a downstream)
+                        self.committed_xids.push(tx.xid);
+                        // Update feedback ONLY after successful commit application
+                        self.last_applied_lsn = commit_lsn.value();
+                        self.feedback.update_applied_lsn(self.last_applied_lsn);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+}
+
+// ─── Tests ───────────────────────────────────────────────────────────────────
+
+/// Verify that transaction events arrive in order: Begin → Insert → Commit,
+/// and that the consumer correctly buffers changes until commit.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_transaction_boundaries() {
+    let slot = "it_safe_txn_boundaries";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_safe_schema(&regular);
+
+    let config = safe_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        cancel_clone.cancel();
+    });
+
+    let mut event_stream = stream.into_stream(cancel_token);
+
+    // A single INSERT transaction
+    regular
+        .exec("INSERT INTO safe_test (name, value) VALUES ('alice', 1)")
+        .expect("INSERT");
+
+    // Track event order
+    let mut event_order: Vec<String> = Vec::new();
+
+    loop {
+        match event_stream.next().await {
+            Ok(event) => {
+                let label = match &event.event_type {
+                    EventType::Begin { .. } => "Begin".to_string(),
+                    EventType::Insert { .. } => "Insert".to_string(),
+                    EventType::Update { .. } => "Update".to_string(),
+                    EventType::Delete { .. } => "Delete".to_string(),
+                    EventType::Commit { .. } => "Commit".to_string(),
+                    EventType::Relation => "Relation".to_string(),
+                    other => format!("{other:?}"),
+                };
+                event_order.push(label.clone());
+
+                if label == "Commit" {
+                    break;
+                }
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => break,
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+
+    println!("Event order: {event_order:?}");
+
+    // Verify ordering: Begin must come before Insert, Insert before Commit
+    let begin_pos = event_order.iter().position(|e| e == "Begin");
+    let insert_pos = event_order.iter().position(|e| e == "Insert");
+    let commit_pos = event_order.iter().position(|e| e == "Commit");
+
+    assert!(begin_pos.is_some(), "expected a Begin event");
+    assert!(insert_pos.is_some(), "expected an Insert event");
+    assert!(commit_pos.is_some(), "expected a Commit event");
+    assert!(
+        begin_pos < insert_pos,
+        "Begin must come before Insert: Begin@{begin_pos:?}, Insert@{insert_pos:?}"
+    );
+    assert!(
+        insert_pos < commit_pos,
+        "Insert must come before Commit: Insert@{insert_pos:?}, Commit@{commit_pos:?}"
+    );
+}
+
+/// Verify the full consumer buffering pattern: buffer changes per transaction,
+/// apply on commit, and update LSN feedback only after commit.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_consumer_buffers_until_commit() {
+    let slot = "it_safe_buffer";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_safe_schema(&regular);
+
+    let config = safe_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    let feedback = stream.shared_lsn_feedback.clone();
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        cancel_clone.cancel();
+    });
+
+    let mut consumer = TestConsumer::new(feedback.clone());
+
+    // Insert multiple rows in a single transaction
+    regular
+        .exec(
+            "INSERT INTO safe_test (name, value) VALUES \
+             ('bob', 10), ('carol', 20), ('dave', 30)",
+        )
+        .expect("INSERT");
+
+    // Process events until the first commit
+    loop {
+        match stream.next_event(&cancel_token).await {
+            Ok(event) => {
+                let is_commit = matches!(event.event_type, EventType::Commit { .. });
+                consumer.process_event(event);
+
+                if is_commit {
+                    break;
+                }
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => break,
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+
+    // Verify: one committed transaction
+    assert_eq!(
+        consumer.committed_xids.len(),
+        1,
+        "expected 1 committed transaction"
+    );
+
+    // No active (uncommitted) transactions should remain
+    assert!(
+        consumer.active_transactions.is_empty(),
+        "all transactions should be committed, found {} active",
+        consumer.active_transactions.len()
+    );
+
+    // Feedback LSN should have been updated after commit
+    assert!(
+        consumer.last_applied_lsn > 0,
+        "applied LSN should be updated after commit"
+    );
+    println!(
+        "Consumer committed xid={}, applied_lsn={}",
+        consumer.committed_xids[0], consumer.last_applied_lsn
+    );
+}
+
+/// Verify that multiple transactions are processed in order and feedback LSN
+/// advances monotonically.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_ordered_multi_transaction_processing() {
+    let slot = "it_safe_multi_tx";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_safe_schema(&regular);
+
+    let config = safe_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    let feedback = stream.shared_lsn_feedback.clone();
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        cancel_clone.cancel();
+    });
+
+    let mut consumer = TestConsumer::new(feedback);
+
+    // Three separate transactions (auto-commit for each statement)
+    regular
+        .exec("INSERT INTO safe_test (name, value) VALUES ('tx1', 100)")
+        .expect("INSERT tx1");
+    regular
+        .exec("INSERT INTO safe_test (name, value) VALUES ('tx2', 200)")
+        .expect("INSERT tx2");
+    regular
+        .exec("INSERT INTO safe_test (name, value) VALUES ('tx3', 300)")
+        .expect("INSERT tx3");
+
+    // Track LSN progression
+    let mut lsn_history: Vec<u64> = Vec::new();
+    let mut commit_count = 0u32;
+
+    loop {
+        match stream.next_event(&cancel_token).await {
+            Ok(event) => {
+                let is_commit = matches!(event.event_type, EventType::Commit { .. });
+                consumer.process_event(event);
+
+                if is_commit {
+                    commit_count += 1;
+                    lsn_history.push(consumer.last_applied_lsn);
+
+                    if commit_count >= 3 {
+                        break;
+                    }
+                }
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => break,
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+
+    assert_eq!(
+        consumer.committed_xids.len(),
+        3,
+        "expected 3 committed transactions, got {}",
+        consumer.committed_xids.len()
+    );
+
+    // LSN must advance monotonically
+    for window in lsn_history.windows(2) {
+        assert!(
+            window[1] > window[0],
+            "LSN must advance: {} should be > {}",
+            window[1],
+            window[0]
+        );
+    }
+
+    println!(
+        "Processed {} transactions in order: xids={:?}, lsns={:?}",
+        consumer.committed_xids.len(),
+        consumer.committed_xids,
+        lsn_history
+    );
+}
+
+/// Verify that mixed DML (insert, update, delete) within a single transaction
+/// is buffered correctly and all changes are available at commit time.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_mixed_dml_transaction() {
+    let slot = "it_safe_mixed_dml";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_safe_schema(&regular);
+
+    // Pre-insert a row to update/delete later
+    regular
+        .exec("INSERT INTO safe_test (name, value) VALUES ('target', 0)")
+        .expect("pre-INSERT");
+
+    let config = safe_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    let feedback = stream.shared_lsn_feedback.clone();
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(10)).await;
+        cancel_clone.cancel();
+    });
+
+    let mut consumer = TestConsumer::new(feedback);
+
+    // Execute mixed DML in separate auto-committed statements
+    // (Insert a new row, update it, then delete it)
+    regular
+        .exec("INSERT INTO safe_test (name, value) VALUES ('mixed', 42)")
+        .expect("INSERT mixed");
+    regular
+        .exec("UPDATE safe_test SET value = 99 WHERE name = 'mixed'")
+        .expect("UPDATE mixed");
+    regular
+        .exec("DELETE FROM safe_test WHERE name = 'mixed'")
+        .expect("DELETE mixed");
+
+    // Collect events from 3 transactions (INSERT, UPDATE, DELETE)
+    let mut commit_count = 0u32;
+    let mut event_types_seen: Vec<String> = Vec::new();
+
+    loop {
+        match stream.next_event(&cancel_token).await {
+            Ok(event) => {
+                match &event.event_type {
+                    EventType::Insert { .. } => event_types_seen.push("Insert".to_string()),
+                    EventType::Update { .. } => event_types_seen.push("Update".to_string()),
+                    EventType::Delete { .. } => event_types_seen.push("Delete".to_string()),
+                    _ => {}
+                }
+
+                let is_commit = matches!(event.event_type, EventType::Commit { .. });
+                consumer.process_event(event);
+
+                if is_commit {
+                    commit_count += 1;
+                    if commit_count >= 3 {
+                        break;
+                    }
+                }
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => break,
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+
+    assert!(
+        event_types_seen.contains(&"Insert".to_string()),
+        "expected Insert event"
+    );
+    assert!(
+        event_types_seen.contains(&"Update".to_string()),
+        "expected Update event"
+    );
+    assert!(
+        event_types_seen.contains(&"Delete".to_string()),
+        "expected Delete event"
+    );
+
+    assert_eq!(consumer.committed_xids.len(), 3, "expected 3 transactions");
+    println!("Mixed DML events: {event_types_seen:?}");
+}
+
+/// Verify graceful shutdown: cancellation stops event processing cleanly
+/// without panics or lost state.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_graceful_shutdown_via_cancellation() {
+    let slot = "it_safe_shutdown";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_safe_schema(&regular);
+
+    let config = safe_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    let feedback = stream.shared_lsn_feedback.clone();
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+
+    // Cancel after 2 seconds (short timeout to test shutdown)
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(2)).await;
+        cancel_clone.cancel();
+    });
+
+    let mut consumer = TestConsumer::new(feedback);
+
+    // Insert some data so there's something to process
+    regular
+        .exec("INSERT INTO safe_test (name, value) VALUES ('shutdown_test', 1)")
+        .expect("INSERT");
+
+    let mut event_count = 0u32;
+    let was_cancelled: bool;
+
+    loop {
+        match stream.next_event(&cancel_token).await {
+            Ok(event) => {
+                event_count += 1;
+                consumer.process_event(event);
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => {
+                was_cancelled = true;
+                break;
+            }
+            Err(e) => panic!("Unexpected error: {e}"),
+        }
+    }
+
+    assert!(
+        was_cancelled,
+        "expected cancellation, but loop exited for another reason"
+    );
+
+    // Consumer state should be consistent (no panic, no corruption)
+    let still_active = consumer.active_transactions.len();
+    println!(
+        "Graceful shutdown after {event_count} events: \
+         {} committed, {still_active} still active (expected for in-flight tx)",
+        consumer.committed_xids.len()
+    );
+}

--- a/integration-tests/snapshot_export.rs
+++ b/integration-tests/snapshot_export.rs
@@ -1,0 +1,423 @@
+//! Integration tests for the EXPORT_SNAPSHOT workflow.
+//!
+//! These tests verify the PostgreSQL snapshot lifecycle when using
+//! `ensure_replication_slot()` with `EXPORT_SNAPSHOT`. They require a live
+//! PostgreSQL instance configured for logical replication.
+//!
+//! ## Prerequisites
+//!
+//! - PostgreSQL 14+ with `wal_level = logical`
+//! - A user with replication privileges
+//! - Environment variable `DATABASE_URL` pointing to a replication-enabled connection
+//!   (e.g. `postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database`)
+//! - Environment variable `DATABASE_URL_REGULAR` pointing to a regular (non-replication)
+//!   connection to the same database (e.g. `postgresql://postgres:postgres@localhost:5432/test_walstream`)
+//!
+//! ## Running Locally
+//!
+//! ```bash
+//! export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+//! export DATABASE_URL_REGULAR="postgresql://postgres:postgres@localhost:5432/test_walstream"
+//! cargo test --test snapshot_export -- --ignored
+//! ```
+
+use pg_walstream::{
+    CancellationToken, LogicalReplicationStream, PgReplicationConnection, ReplicationSlotOptions,
+    ReplicationStreamConfig, RetryConfig, StreamingMode,
+};
+use std::time::Duration;
+
+/// Return the replication connection string from environment, or skip.
+fn replication_conn_string() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+            .to_string()
+    })
+}
+
+/// Return the regular (non-replication) connection string from environment, or derive it.
+fn regular_conn_string() -> String {
+    std::env::var("DATABASE_URL_REGULAR").unwrap_or_else(|_| {
+        // Strip `replication=database` from the replication connection string
+        let repl = replication_conn_string();
+        repl.replace("?replication=database", "")
+            .replace("&replication=database", "")
+    })
+}
+
+/// Create a helper config with a unique slot name to avoid collisions between tests.
+fn test_config(slot_name: &str) -> ReplicationStreamConfig {
+    ReplicationStreamConfig::new(
+        slot_name.to_string(),
+        "test_pub".to_string(),
+        2,
+        StreamingMode::On,
+        Duration::from_secs(10),
+        Duration::from_secs(30),
+        Duration::from_secs(60),
+        RetryConfig::default(),
+    )
+    .with_slot_options(ReplicationSlotOptions {
+        temporary: true,
+        snapshot: Some("export".to_string()),
+        ..Default::default()
+    })
+}
+
+/// Helper: set up the test schema (idempotent).
+fn setup_schema(regular_conn: &PgReplicationConnection) {
+    // Create table if not exists
+    let _ = regular_conn.exec(
+        "CREATE TABLE IF NOT EXISTS snapshot_test (id SERIAL PRIMARY KEY, name TEXT NOT NULL)",
+    );
+
+    // Clear and seed data
+    let _ = regular_conn.exec("TRUNCATE snapshot_test RESTART IDENTITY");
+    let _ = regular_conn
+        .exec("INSERT INTO snapshot_test (name) VALUES ('alice'), ('bob'), ('charlie')");
+
+    // Create publication if not exists (ignore errors if it already exists)
+    let _ = regular_conn.exec("DROP PUBLICATION IF EXISTS test_pub");
+    let _ = regular_conn.exec("CREATE PUBLICATION test_pub FOR TABLE snapshot_test");
+}
+
+/// Helper: clean up a replication slot (best-effort).
+fn drop_slot(slot_name: &str) {
+    if let Ok(conn) = PgReplicationConnection::connect(&replication_conn_string()) {
+        let _ = conn.exec(&format!(
+            "SELECT pg_drop_replication_slot('{}') WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{}')",
+            slot_name, slot_name
+        ));
+    }
+}
+
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_ensure_slot_returns_snapshot_name() {
+    let slot = "it_snap_name";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_schema(&regular);
+
+    let config = test_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    stream
+        .ensure_replication_slot()
+        .await
+        .expect("ensure_replication_slot");
+
+    let snap = stream.exported_snapshot_name();
+    assert!(
+        snap.is_some(),
+        "exported_snapshot_name() must be Some after EXPORT_SNAPSHOT"
+    );
+    let snap_name = snap.unwrap();
+    assert!(!snap_name.is_empty(), "snapshot name must not be empty");
+    println!("Exported snapshot: {snap_name}");
+}
+
+/// Verify the full snapshot workflow:
+///   1. `ensure_replication_slot()` → snapshot name
+///   2. Use the snapshot on a **separate regular connection** to read consistent data
+///   3. `start()` proceeds without re-creating the slot
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_snapshot_readable_before_start() {
+    let slot = "it_snap_read";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_schema(&regular);
+
+    let config = test_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    // Step 1: create slot, get snapshot
+    stream
+        .ensure_replication_slot()
+        .await
+        .expect("ensure_replication_slot");
+
+    let snap_name = stream
+        .exported_snapshot_name()
+        .expect("snapshot must exist");
+    println!("Snapshot: {snap_name}");
+
+    // Step 2: open a separate regular connection, import the snapshot, read data
+    let reader = PgReplicationConnection::connect(&regular_conn_string())
+        .expect("snapshot reader connection");
+
+    reader
+        .exec("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        .expect("BEGIN");
+
+    reader
+        .exec(&format!("SET TRANSACTION SNAPSHOT '{snap_name}'"))
+        .expect("SET TRANSACTION SNAPSHOT must succeed before START_REPLICATION");
+
+    let result = reader
+        .exec("SELECT id, name FROM snapshot_test ORDER BY id")
+        .expect("SELECT");
+
+    let row_count = result.ntuples();
+    assert_eq!(row_count, 3, "expected 3 seeded rows, got {row_count}");
+
+    // Verify actual data
+    assert_eq!(result.get_value(0, 1).as_deref(), Some("alice"));
+    assert_eq!(result.get_value(1, 1).as_deref(), Some("bob"));
+    assert_eq!(result.get_value(2, 1).as_deref(), Some("charlie"));
+
+    reader.exec("COMMIT").expect("COMMIT");
+
+    // Step 3: start streaming — this should NOT re-create the slot
+    stream.start(None).await.expect("start");
+
+    println!("Stream started successfully after snapshot read — workflow complete");
+}
+
+/// Verify that the snapshot becomes **invalid** after `start()` issues
+/// `START_REPLICATION`.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_snapshot_invalid_after_start() {
+    let slot = "it_snap_invalid";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_schema(&regular);
+
+    let config = test_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    stream
+        .ensure_replication_slot()
+        .await
+        .expect("ensure_replication_slot");
+
+    let snap_name = stream
+        .exported_snapshot_name()
+        .expect("snapshot must exist")
+        .to_string();
+
+    // Start replication — this destroys the snapshot
+    stream.start(None).await.expect("start");
+
+    // Now try to use the snapshot on a separate connection — it MUST fail
+    let reader = PgReplicationConnection::connect(&regular_conn_string())
+        .expect("snapshot reader connection");
+
+    reader
+        .exec("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        .expect("BEGIN");
+
+    let result = reader.exec(&format!("SET TRANSACTION SNAPSHOT '{snap_name}'"));
+    assert!(
+        result.is_err(),
+        "SET TRANSACTION SNAPSHOT must fail after START_REPLICATION, \
+         but it succeeded. The snapshot should have been destroyed."
+    );
+
+    let _ = reader.exec("ROLLBACK");
+    println!("Confirmed: snapshot '{snap_name}' is invalid after start()");
+}
+
+/// Verify that `ensure_replication_slot()` is idempotent — calling it twice
+/// is a no-op the second time.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_ensure_slot_idempotent() {
+    let slot = "it_snap_idempotent";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_schema(&regular);
+
+    let config = test_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    // First call — creates the slot
+    stream
+        .ensure_replication_slot()
+        .await
+        .expect("first ensure_replication_slot");
+
+    let snap1 = stream
+        .exported_snapshot_name()
+        .expect("snapshot from first call")
+        .to_string();
+
+    // Second call — should be a no-op (slot_created is true)
+    stream
+        .ensure_replication_slot()
+        .await
+        .expect("second ensure_replication_slot");
+
+    let snap2 = stream
+        .exported_snapshot_name()
+        .expect("snapshot after second call");
+
+    assert_eq!(
+        snap1, snap2,
+        "snapshot name must remain the same after idempotent call"
+    );
+}
+
+/// Verify that `NOEXPORT_SNAPSHOT` results in `exported_snapshot_name()` returning `None`.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_noexport_snapshot_returns_none() {
+    let slot = "it_snap_noexport";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_schema(&regular);
+
+    let config = ReplicationStreamConfig::new(
+        slot.to_string(),
+        "test_pub".to_string(),
+        2,
+        StreamingMode::On,
+        Duration::from_secs(10),
+        Duration::from_secs(30),
+        Duration::from_secs(60),
+        RetryConfig::default(),
+    )
+    .with_slot_options(ReplicationSlotOptions {
+        temporary: true,
+        snapshot: Some("nothing".to_string()), // NOEXPORT_SNAPSHOT
+        ..Default::default()
+    });
+
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    stream
+        .ensure_replication_slot()
+        .await
+        .expect("ensure_replication_slot");
+
+    // NOEXPORT_SNAPSHOT should produce either None or an empty string
+    let snap = stream.exported_snapshot_name();
+    assert!(
+        snap.is_none() || snap.is_some_and(str::is_empty),
+        "No snapshot should be exported with NOEXPORT_SNAPSHOT, got: {snap:?}"
+    );
+}
+
+/// End-to-end: snapshot read + stream a few events (insert during the test),
+/// confirming no data gap between snapshot and stream.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn test_snapshot_and_stream_consistency() {
+    let slot = "it_snap_consistency";
+    drop_slot(slot);
+
+    let regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    setup_schema(&regular);
+
+    let config = test_config(slot);
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), config)
+        .await
+        .expect("replication stream");
+
+    // Step 1: create slot
+    stream
+        .ensure_replication_slot()
+        .await
+        .expect("ensure_replication_slot");
+
+    let snap_name = stream
+        .exported_snapshot_name()
+        .expect("snapshot must exist");
+
+    // Step 2: read initial state through the snapshot
+    let reader = PgReplicationConnection::connect(&regular_conn_string())
+        .expect("snapshot reader connection");
+
+    reader
+        .exec("BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ")
+        .expect("BEGIN");
+    reader
+        .exec(&format!("SET TRANSACTION SNAPSHOT '{snap_name}'"))
+        .expect("SET TRANSACTION SNAPSHOT");
+
+    let snapshot_rows = reader
+        .exec("SELECT count(*) FROM snapshot_test")
+        .expect("SELECT count");
+    let count_str = snapshot_rows.get_value(0, 0).unwrap_or_default();
+    let initial_count: i32 = count_str.parse().unwrap_or(0);
+    assert_eq!(initial_count, 3, "expected 3 rows in snapshot");
+
+    reader.exec("COMMIT").expect("COMMIT");
+
+    // Insert new data AFTER the snapshot was taken but BEFORE start()
+    regular
+        .exec("INSERT INTO snapshot_test (name) VALUES ('dave')")
+        .expect("INSERT dave");
+
+    // Step 3: start streaming
+    stream.start(None).await.expect("start");
+
+    let cancel_token = CancellationToken::new();
+    let cancel_clone = cancel_token.clone();
+
+    // Auto-cancel after 5 seconds to avoid hanging
+    tokio::spawn(async move {
+        tokio::time::sleep(Duration::from_secs(5)).await;
+        cancel_clone.cancel();
+    });
+
+    // Trigger another insert to make sure we get at least one event
+    // (dave's insert happened before START_REPLICATION, so it will
+    // arrive as a streamed event)
+    regular
+        .exec("INSERT INTO snapshot_test (name) VALUES ('eve')")
+        .expect("INSERT eve");
+
+    let mut event_count = 0u32;
+    loop {
+        match stream.next_event(&cancel_token).await {
+            Ok(event) => {
+                event_count += 1;
+                println!("Event #{event_count}: {:?}", event.event_type);
+                stream
+                    .shared_lsn_feedback
+                    .update_applied_lsn(event.lsn.value());
+                // We just need to confirm we can receive events — break early
+                if event_count >= 1 {
+                    break;
+                }
+            }
+            Err(pg_walstream::ReplicationError::Cancelled(_)) => {
+                println!("Stream cancelled after {event_count} events");
+                break;
+            }
+            Err(e) => {
+                panic!("Unexpected stream error: {e}");
+            }
+        }
+    }
+
+    assert!(
+        event_count >= 1,
+        "Expected at least 1 streamed event, got {event_count}"
+    );
+    println!("Snapshot + stream consistency test passed: {initial_count} initial rows, {event_count} streamed events");
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,7 +61,12 @@
 //!         "postgresql://postgres:password@localhost:5432/mydb?replication=database",
 //!         config,
 //!     ).await?;
-//!     
+//!
+//!     // Optional: create the slot first to use the exported snapshot
+//!     // for an initial consistent table read (before start() destroys it).
+//!     // stream.ensure_replication_slot().await?;
+//!     // if let Some(snap) = stream.exported_snapshot_name() { /* read snapshot */ }
+//!
 //!     stream.start(None).await?;
 //!
 //!     let cancel_token = CancellationToken::new();


### PR DESCRIPTION
- Implemented `rate_limited_streaming.rs` to test the `EventStream` API for rate-controlled event processing, including event type categorization and LSN feedback.
- Created `safe_transaction_consumer.rs` to verify transaction boundaries, buffering changes until commit, and graceful shutdown with cancellation.
- ensuring snapshot lifecycle management and consistency between snapshot reads and streaming events.
- Enhance integration tests by increasing replication slot limits and adding cleanup for lingering slots

for #25