### PR TITLE
feat: add serde Deserializer for RowData with typed-row API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,7 @@ rustls-tls = [
 tokio = { version = "1.51.1", features = ["full"] }
 criterion = { version = "0.8.2", features = ["html_reports"] }
 futures = "0.3.32"
+serde_bytes = "0.11.19"
 
 [[test]]
 name = "snapshot_export"

--- a/examples/README.md
+++ b/examples/README.md
@@ -144,6 +144,26 @@ cd examples/arbitrary-fuzzing
 cargo run
 ```
 
+### 7. typed-deserialization
+
+Demonstrates deserializing WAL event data directly into user-defined Rust structs using `RowData::deserialize_into()`.
+
+- Automatic text-to-type coercion (PostgreSQL sends all values as text)
+- NULL handling with `Option<T>` fields
+- `#[serde(rename)]` for column-to-field name mapping
+- `#[serde(default)]` for missing/evolving columns
+- Enum deserialization from text columns
+- `ChangeEvent` convenience methods (`deserialize_insert`, `deserialize_update`, etc.)
+- Error handling for type mismatches and NULL violations
+
+**Run:**
+```bash
+cd examples/typed-deserialization
+cargo run
+```
+
+**No database required** — this example uses in-memory `RowData` and `ChangeEvent` objects to demonstrate the deserialization API.
+
 ## Prerequisites
 
 ### For Logical Replication Examples (basic_streaming, polling_example, safe_transaction_consumer)

--- a/examples/typed-deserialization/Cargo.lock
+++ b/examples/typed-deserialization/Cargo.lock
@@ -12,15 +12,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloca"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e5a7d05ea6aea7e9e64d25b9156ba2fee3fdd659e34e41063cd2fc7cd020d7f4"
-dependencies = [
- "cc",
-]
-
-[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -30,22 +21,21 @@ dependencies = [
 ]
 
 [[package]]
-name = "anes"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
-
-[[package]]
-name = "anstyle"
-version = "1.0.13"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
-
-[[package]]
 name = "anyhow"
 version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
+
+[[package]]
+name = "async-trait"
+version = "0.1.89"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "autocfg"
@@ -55,9 +45,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -66,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -112,9 +102,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -127,9 +117,9 @@ dependencies = [
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "byteorder"
@@ -147,16 +137,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "cast"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
-
-[[package]]
 name = "cc"
-version = "1.2.50"
+version = "1.2.60"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f50d563227a1c37cc0a263f64eca3334388c01c5e4c4861a9def205c614383c"
+checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -205,33 +189,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ciborium"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42e69ffd6f0917f5c029256a24d0161db17cea3997d185db0d35926308770f0e"
-dependencies = [
- "ciborium-io",
- "ciborium-ll",
- "serde",
-]
-
-[[package]]
-name = "ciborium-io"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "05afea1e0a06c9be33d539b876f1ce3692f4afea2cb41f740e7743225ed1c757"
-
-[[package]]
-name = "ciborium-ll"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
-dependencies = [
- "ciborium-io",
- "half",
-]
-
-[[package]]
 name = "clang-sys"
 version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -241,31 +198,6 @@ dependencies = [
  "libc",
  "libloading",
 ]
-
-[[package]]
-name = "clap"
-version = "4.5.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
-dependencies = [
- "clap_builder",
-]
-
-[[package]]
-name = "clap_builder"
-version = "4.5.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
-dependencies = [
- "anstyle",
- "clap_lex",
-]
-
-[[package]]
-name = "clap_lex"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
 
 [[package]]
 name = "cmake"
@@ -302,72 +234,6 @@ checksum = "8b2a41393f66f16b0823bb79094d54ac5fbd34ab292ddafb9a0456ac9f87d201"
 dependencies = [
  "libc",
 ]
-
-[[package]]
-name = "criterion"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "950046b2aa2492f9a536f5f4f9a3de7b9e2476e575e05bd6c333371add4d98f3"
-dependencies = [
- "alloca",
- "anes",
- "cast",
- "ciborium",
- "clap",
- "criterion-plot",
- "itertools",
- "num-traits",
- "oorandom",
- "page_size",
- "plotters",
- "rayon",
- "regex",
- "serde",
- "serde_json",
- "tinytemplate",
- "walkdir",
-]
-
-[[package]]
-name = "criterion-plot"
-version = "0.8.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
-dependencies = [
- "cast",
- "itertools",
-]
-
-[[package]]
-name = "crossbeam-deque"
-version = "0.8.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9dd111b7b7f7d55b72c0a6ae361660ee5853c9af73f70c3c2ef6858b950e2e51"
-dependencies = [
- "crossbeam-epoch",
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-epoch"
-version = "0.9.18"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b82ac4a3c2ca9c3460964f020e1402edd5753411d7737aa39c3714ad1b5420e"
-dependencies = [
- "crossbeam-utils",
-]
-
-[[package]]
-name = "crossbeam-utils"
-version = "0.8.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
-
-[[package]]
-name = "crunchy"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
 name = "crypto-common"
@@ -435,9 +301,9 @@ checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.5"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a3076410a55c90011c298b04d0cfa770b00fa04e1e3c97d3f6c9de105a03844"
+checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
 
 [[package]]
 name = "foldhash"
@@ -446,25 +312,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
+
+[[package]]
 name = "fs_extra"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
-
-[[package]]
-name = "futures"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
-dependencies = [
- "futures-channel",
- "futures-core",
- "futures-executor",
- "futures-io",
- "futures-sink",
- "futures-task",
- "futures-util",
-]
 
 [[package]]
 name = "futures-channel"
@@ -481,34 +347,6 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
-
-[[package]]
-name = "futures-executor"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf29c38818342a3b26b5b923639e7b1f4a61fc5e76102d4b1981c6dc7a7579d"
-dependencies = [
- "futures-core",
- "futures-task",
- "futures-util",
-]
-
-[[package]]
-name = "futures-io"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-macro"
-version = "0.3.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
 
 [[package]]
 name = "futures-sink"
@@ -528,15 +366,10 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
- "futures-channel",
  "futures-core",
- "futures-io",
- "futures-macro",
  "futures-sink",
  "futures-task",
- "memchr",
  "pin-project-lite",
- "slab",
 ]
 
 [[package]]
@@ -547,7 +380,7 @@ checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
 ]
 
 [[package]]
@@ -581,17 +414,6 @@ name = "glob"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
-name = "half"
-version = "2.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
-dependencies = [
- "cfg-if",
- "crunchy",
- "zerocopy",
-]
 
 [[package]]
 name = "hashbrown"
@@ -684,19 +506,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
-version = "1.0.16"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ee5b5339afb4c41626dde77b7a611bd4f2c202b897852b4bcf5d03eddc61010"
+checksum = "8f42a60cbdf9a97f5d2305f08a87dc4e09308d1276d28c869c684d7777685682"
 
 [[package]]
 name = "jobserver"
@@ -710,9 +523,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.83"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "464a3709c7f55f1f721e5389aa6ea4e3bc6aba669353300af094b29ffbdde1d8"
+checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -761,6 +574,15 @@ dependencies = [
  "bindgen",
  "pkg-config",
  "vcpkg",
+]
+
+[[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -813,7 +635,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50b7e5b27aa02a74bac8c3f23f448f8d87ff11f92d3aac1a6ed369ee08cc56c1"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys 0.61.2",
 ]
 
@@ -837,25 +659,65 @@ dependencies = [
 ]
 
 [[package]]
-name = "once_cell"
-version = "1.21.3"
+name = "objc2-core-foundation"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
-
-[[package]]
-name = "oorandom"
-version = "11.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
-
-[[package]]
-name = "page_size"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
+ "bitflags 2.11.1",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "once_cell"
+version = "1.21.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+
+[[package]]
+name = "openssl"
+version = "0.10.77"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfe4646e360ec77dff7dde40ed3d6c5fee52d156ef4a62f53973d38294dad87f"
+dependencies = [
+ "bitflags 2.11.1",
+ "cfg-if",
+ "foreign-types",
  "libc",
- "winapi",
+ "once_cell",
+ "openssl-macros",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.113"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ad2f2c0eba47118757e4c6d2bff2838f3e0523380021356e7875e858372ce644"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -888,27 +750,49 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
+name = "percent-encoding"
+version = "2.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
 name = "pg_walstream"
 version = "0.6.1"
 dependencies = [
  "aws-lc-rs",
  "bytes",
  "chrono",
- "criterion",
- "futures",
  "futures-core",
  "libpq-sys",
  "memchr",
  "postgres-protocol",
  "rustls",
  "serde",
- "serde_bytes",
  "socket2",
  "tokio",
  "tokio-rustls",
  "tokio-util",
  "tracing",
  "webpki-roots",
+]
+
+[[package]]
+name = "phf"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
+dependencies = [
+ "phf_shared",
+ "serde",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e57fef6bc5981e38c2ce2d63bfa546861309f875b8a75f092d1d54ae2d64f266"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -919,36 +803,20 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.32"
+version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7edddbd0b52d732b21ad9a5fab5c704c14cd949e5e9a1ec5929a24fded1b904c"
+checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
 
 [[package]]
-name = "plotters"
-version = "0.3.7"
+name = "postgres-openssl"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5aeb6f403d7a4911efb1e33402027fc44f29b5bf6def3effcc22d7bb75f2b747"
+checksum = "06743eefaa1a5c0ef2ccb6d9abf6528790a229eabd62ddcabf9b2a3aeff09fa4"
 dependencies = [
- "num-traits",
- "plotters-backend",
- "plotters-svg",
- "wasm-bindgen",
- "web-sys",
-]
-
-[[package]]
-name = "plotters-backend"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df42e13c12958a16b3f7f4386b9ab1f3e7933914ecea48da7139435263a4172a"
-
-[[package]]
-name = "plotters-svg"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51bae2ac328883f7acdfea3d66a7c35751187f870bc81f94563733a154d7a670"
-dependencies = [
- "plotters-backend",
+ "openssl",
+ "tokio",
+ "tokio-openssl",
+ "tokio-postgres",
 ]
 
 [[package]]
@@ -970,29 +838,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "postgres-types"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8dc729a129e682e8d24170cd30ae1aa01b336b096cbb56df6d534ffec133d186"
+dependencies = [
+ "bytes",
+ "fallible-iterator",
+ "postgres-protocol",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.103"
+version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ee95bc4ef87b8d5ba32e8b7714ccc834865276eab0aed5c9958d00ec45f49e8"
+checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.42"
+version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a338cc41d27e6cc6dce6cefc13a0729dfbb81c262b1f519331575dd80ef3067f"
+checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
 ]
@@ -1022,29 +901,9 @@ dependencies = [
 
 [[package]]
 name = "rand_core"
-version = "0.10.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c8d0fd677905edcbeedbf2edb6494d676f0e98d54d5cf9bda0b061cb8fb8aba"
-
-[[package]]
-name = "rayon"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
-dependencies = [
- "either",
- "rayon-core",
-]
-
-[[package]]
-name = "rayon-core"
-version = "1.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
-dependencies = [
- "crossbeam-deque",
- "crossbeam-utils",
-]
+checksum = "63b8176103e19a2643978565ca18b50549f6101881c443590420e4dc998a3c69"
 
 [[package]]
 name = "redox_syscall"
@@ -1052,14 +911,14 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.2"
+version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843bc0191f75f3e22651ae5f1e72939ab2f72a4bc30fa80a066bd66edefc24d4"
+checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1069,9 +928,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.13"
+version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5276caf25ac86c8d810222b3dbb938e512c55c6831a10f3e6ed1c93b84041f1c"
+checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -1080,9 +939,9 @@ dependencies = [
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.8"
+version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a2d987857b319362043e95f5353c0535c1f58eec5336fdfcf626430af7def58"
+checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "ring"
@@ -1110,7 +969,7 @@ version = "0.38.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "errno",
  "libc",
  "linux-raw-sys",
@@ -1160,15 +1019,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
 
 [[package]]
-name = "same-file"
-version = "1.0.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1191,16 +1041,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_bytes"
-version = "0.11.19"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
-dependencies = [
- "serde",
- "serde_core",
-]
-
-[[package]]
 name = "serde_core"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,7 +1057,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1261,10 +1101,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "slab"
-version = "0.4.12"
+name = "siphasher"
+version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
@@ -1312,23 +1152,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.111"
+version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "390cc9a294ab71bdb1aa2e99d13be9c753cd2d7bd6560c77118597410c4d2e87"
+checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "tinytemplate"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be4d6b5f19ff7664e8c98d03e2139cb510db9b0a60b55f8e8709b689d939b6bc"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -1348,9 +1178,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.51.1"
+version = "1.52.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f66bf9585cda4b724d3e78ab34b73fb2bbaba9011b9bfdf69dc836382ea13b8c"
+checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
 dependencies = [
  "bytes",
  "libc",
@@ -1371,7 +1201,44 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-openssl"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59df6849caa43bb7567f9a36f863c447d95a11d5903c9cc334ba32576a27eadd"
+dependencies = [
+ "openssl",
+ "openssl-sys",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-postgres"
+version = "0.7.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4dd8df5ef180f6364759a6f00f7aadda4fbbac86cdee37480826a6ff9f3574ce"
+dependencies = [
+ "async-trait",
+ "byteorder",
+ "bytes",
+ "fallible-iterator",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "parking_lot",
+ "percent-encoding",
+ "phf",
+ "pin-project-lite",
+ "postgres-protocol",
+ "postgres-types",
+ "rand",
+ "socket2",
+ "tokio",
+ "tokio-util",
+ "whoami",
 ]
 
 [[package]]
@@ -1416,7 +1283,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1429,10 +1296,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-deserialization"
+version = "0.1.0"
+dependencies = [
+ "chrono",
+ "openssl",
+ "pg_walstream",
+ "postgres-openssl",
+ "rustls",
+ "serde",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-bidi"
@@ -1442,9 +1323,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.22"
+version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9312f7c4f6ff9069b165498234ce8be658059c6728633667c526e27dc2cf1df5"
+checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
 name = "unicode-normalization"
@@ -1486,28 +1367,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
-name = "walkdir"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "29790946404f91d9c5d06f9874efddea1dc06c5efe94541a7d6863108e3a5e4b"
-dependencies = [
- "same-file",
- "winapi-util",
-]
-
-[[package]]
 name = "wasi"
 version = "0.11.1+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
 dependencies = [
- "wit-bindgen",
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.3+wasi-0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
+dependencies = [
+ "wit-bindgen 0.57.1",
 ]
 
 [[package]]
@@ -1516,14 +1396,23 @@ version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.51.0",
+]
+
+[[package]]
+name = "wasite"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66fe902b4a6b8028a753d5424909b764ccf79b7a209eac9bf97e59cda9f71a42"
+dependencies = [
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.106"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d759f433fa64a2d763d1340820e46e111a7a5ab75f993d1852d70b03dbb80fd"
+checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1534,9 +1423,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.106"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48cb0d2638f8baedbc542ed444afc0644a29166f1595371af4fecf8ce1e7eeb3"
+checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1544,22 +1433,22 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.106"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cefb59d5cd5f92d9dcf80e4683949f15ca4b511f4ac0a6e14d4e1ac60c6ecd40"
+checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
 dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.106"
+version = "0.2.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cbc538057e648b67f72a982e708d485b2efa771e1ac05fec311f9f63e5800db4"
+checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
 dependencies = [
  "unicode-ident",
 ]
@@ -1592,7 +1481,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1600,9 +1489,9 @@ dependencies = [
 
 [[package]]
 name = "web-sys"
-version = "0.3.83"
+version = "0.3.95"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b32828d774c412041098d182a8b38b16ea816958e07cf40eec2bc080ae137ac"
+checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1610,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1630,35 +1519,17 @@ dependencies = [
 ]
 
 [[package]]
-name = "winapi"
-version = "0.3.9"
+name = "whoami"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c839a674fcd7a98952e593242ea400abe93992746761e38641405d28b00f419"
+checksum = "d6a5b12f9df4f978d2cfdb1bd3bac52433f44393342d7ee9c25f5a1c14c0f45d"
 dependencies = [
- "winapi-i686-pc-windows-gnu",
- "winapi-x86_64-pc-windows-gnu",
+ "libc",
+ "libredox",
+ "objc2-system-configuration",
+ "wasite",
+ "web-sys",
 ]
-
-[[package]]
-name = "winapi-i686-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
-
-[[package]]
-name = "winapi-util"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
-dependencies = [
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "winapi-x86_64-pc-windows-gnu"
-version = "0.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows-core"
@@ -1681,7 +1552,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1692,7 +1563,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1820,6 +1691,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "wit-bindgen"
+version = "0.57.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
 name = "wit-bindgen-core"
 version = "0.51.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1840,7 +1717,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -1856,7 +1733,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.111",
+ "syn 2.0.117",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -1868,7 +1745,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.0",
+ "bitflags 2.11.1",
  "indexmap",
  "log",
  "serde",
@@ -1899,26 +1776,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zerocopy"
-version = "0.8.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.39"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.111",
-]
-
-[[package]]
 name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1926,6 +1783,6 @@ checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zmij"
-version = "1.0.13"
+version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac93432f5b761b22864c774aac244fa5c0fd877678a4c37ebf6cf42208f9c9ec"
+checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"

--- a/examples/typed-deserialization/Cargo.toml
+++ b/examples/typed-deserialization/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "typed-deserialization"
+version = "0.1.0"
+edition = "2021"
+publish = false
+description = "Demonstrates deserializing WAL events into user-defined Rust structs from a live PostgreSQL database"
+
+[features]
+default = ["rustls-tls"]
+rustls-tls = ["pg_walstream/rustls-tls", "dep:rustls"]
+libpq = ["pg_walstream/libpq"]
+
+[dependencies]
+pg_walstream = { path = "../..", default-features = false }
+rustls = { version = "0.23.38", default-features = false, features = ["aws_lc_rs"], optional = true }
+serde = { version = "1.0.228", features = ["derive"] }
+tokio = { version = "1.51.1", features = ["full"] }
+tokio-postgres = "0.7.17"
+postgres-openssl = "0.5.3"
+openssl = "0.10.76"
+chrono = "0.4.44"

--- a/examples/typed-deserialization/src/main.rs
+++ b/examples/typed-deserialization/src/main.rs
@@ -1,0 +1,454 @@
+//! Typed Deserialization Example (Live Database)
+//!
+//! Demonstrates how to connect to a real PostgreSQL database, stream WAL events
+//! via `next_event()`, and deserialize them into user-defined Rust structs using
+//! `ChangeEvent::deserialize_insert()`, `deserialize_update()`, etc.
+//!
+//! ## Prerequisites
+//!
+//! 1. PostgreSQL with `wal_level = logical`
+//! 2. Set `DATABASE_URL` environment variable
+//!
+//! ## Running
+//!
+//! ```bash
+//! cd examples/typed-deserialization
+//! DATABASE_URL='postgresql://postgres:pass@host:5432/db?replication=database&sslmode=require' cargo run
+//! ```
+//!
+//! Then in another terminal, run SQL against the same database:
+//! ```sql
+//! INSERT INTO users (username, email, score, active) VALUES ('alice', 'alice@example.com', 95.5, true);
+//! UPDATE users SET score = 99.0 WHERE username = 'alice';
+//! DELETE FROM users WHERE username = 'alice';
+//! ```
+
+use openssl::ssl::{SslConnector, SslMethod, SslVerifyMode};
+use pg_walstream::{
+    CancellationToken, EventType, LogicalReplicationStream, ReplicationSlotOptions,
+    ReplicationStreamConfig, RetryConfig, StreamingMode,
+};
+use postgres_openssl::MakeTlsConnector;
+use serde::Deserialize;
+use std::time::Duration;
+
+// ---------------------------------------------------------------------------
+// 1. Define your model structs — just derive Deserialize
+// ---------------------------------------------------------------------------
+
+/// Matches the `users` table we create below:
+/// ```sql
+/// CREATE TABLE users (
+///     id         BIGSERIAL PRIMARY KEY,
+///     username   VARCHAR(50) NOT NULL,
+///     email      TEXT,
+///     score      DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+///     active     BOOLEAN NOT NULL DEFAULT true
+/// );
+/// ```
+#[derive(Debug, Deserialize)]
+struct User {
+    id: i64,
+    username: String,
+    email: Option<String>, // nullable column → Option
+    score: f64,
+    active: bool,
+}
+
+// ---------------------------------------------------------------------------
+// Configuration
+// ---------------------------------------------------------------------------
+
+const TABLE_NAME: &str = "typed_deser_users";
+const PUBLICATION: &str = "typed_deser_pub";
+const SLOT_NAME: &str = "typed_deser_slot";
+
+// ---------------------------------------------------------------------------
+// Database helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Clone)]
+struct DbConfig {
+    host: String,
+    port: u16,
+    db: String,
+    user: String,
+    pass: String,
+    sslmode: String,
+}
+
+fn parse_db_config() -> DbConfig {
+    let url = std::env::var("DATABASE_URL").expect(
+        "DATABASE_URL env var required.\n\
+         Example: DATABASE_URL='postgresql://postgres:pass@localhost:5432/postgres?replication=database'",
+    );
+
+    let url = url
+        .trim_start_matches("postgresql://")
+        .trim_start_matches("postgres://");
+
+    let (creds, rest) = url.split_once('@').unwrap_or(("postgres:postgres", url));
+    let (user, pass) = creds.split_once(':').unwrap_or((creds, ""));
+
+    let (host_port, db_params) = rest.split_once('/').unwrap_or((rest, "postgres"));
+    let (host, port) = if host_port.contains(':') {
+        let (h, p) = host_port.rsplit_once(':').unwrap();
+        (h, p.parse::<u16>().unwrap_or(5432))
+    } else {
+        (host_port, 5432)
+    };
+
+    let (db, params) = db_params.split_once('?').unwrap_or((db_params, ""));
+
+    let mut sslmode = "prefer".to_string();
+    for param in params.split('&') {
+        if let Some(val) = param.strip_prefix("sslmode=") {
+            sslmode = val.to_string();
+        }
+    }
+
+    DbConfig {
+        host: host.to_string(),
+        port,
+        db: db.to_string(),
+        user: user.to_string(),
+        pass: pass.to_string(),
+        sslmode,
+    }
+}
+
+fn repl_conn_string(cfg: &DbConfig) -> String {
+    format!(
+        "postgresql://{}:{}@{}:{}/{}?replication=database&sslmode={}",
+        cfg.user, cfg.pass, cfg.host, cfg.port, cfg.db, cfg.sslmode
+    )
+}
+
+fn regular_conn_string(cfg: &DbConfig) -> String {
+    format!(
+        "host={} port={} dbname={} user={} password={} sslmode={}",
+        cfg.host, cfg.port, cfg.db, cfg.user, cfg.pass, cfg.sslmode
+    )
+}
+
+async fn pg_connect(conn_str: &str) -> tokio_postgres::Client {
+    let mut builder = SslConnector::builder(SslMethod::tls()).unwrap();
+    builder.set_verify(SslVerifyMode::NONE);
+    let tls = MakeTlsConnector::new(builder.build());
+    let (client, conn) = tokio_postgres::connect(conn_str, tls)
+        .await
+        .expect("Failed to connect to PostgreSQL");
+    tokio::spawn(async move {
+        let _ = conn.await;
+    });
+    client
+}
+
+// ---------------------------------------------------------------------------
+// Setup & cleanup
+// ---------------------------------------------------------------------------
+
+async fn setup_database(cfg: &DbConfig) {
+    println!("Setting up table and publication...");
+    let client = pg_connect(&regular_conn_string(cfg)).await;
+
+    let create_table = format!(
+        "CREATE TABLE IF NOT EXISTS {TABLE_NAME} (
+            id BIGSERIAL PRIMARY KEY,
+            username VARCHAR(50) NOT NULL,
+            email TEXT,
+            score DOUBLE PRECISION NOT NULL DEFAULT 0.0,
+            active BOOLEAN NOT NULL DEFAULT true
+        )"
+    );
+    client.execute(&create_table as &str, &[]).await.unwrap();
+
+    let _ = client
+        .execute(
+            &format!("ALTER TABLE {TABLE_NAME} REPLICA IDENTITY FULL") as &str,
+            &[],
+        )
+        .await;
+
+    let pub_exists = client
+        .query(
+            "SELECT 1 FROM pg_publication WHERE pubname = $1",
+            &[&PUBLICATION],
+        )
+        .await
+        .map(|rows| !rows.is_empty())
+        .unwrap_or(false);
+
+    if !pub_exists {
+        let sql = format!("CREATE PUBLICATION {PUBLICATION} FOR TABLE {TABLE_NAME}");
+        match client.execute(&sql as &str, &[]).await {
+            Ok(_) => println!("Created publication: {PUBLICATION}"),
+            Err(e) => println!("Publication note: {e}"),
+        }
+    }
+
+    // Drop old slot if exists
+    let drop_sql = format!(
+        "SELECT pg_drop_replication_slot('{SLOT_NAME}') \
+         WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{SLOT_NAME}')"
+    );
+    let _ = client.execute(&drop_sql as &str, &[]).await;
+
+    // Seed some initial data so there's something to see
+    let count: i64 = client
+        .query_one(
+            &format!("SELECT count(*) FROM {TABLE_NAME}") as &str,
+            &[],
+        )
+        .await
+        .unwrap()
+        .get(0);
+
+    if count == 0 {
+        println!("Seeding initial data...");
+        client
+            .execute(
+                &format!(
+                    "INSERT INTO {TABLE_NAME} (username, email, score, active) VALUES
+                     ('alice', 'alice@example.com', 95.5, true),
+                     ('bob', NULL, 72.0, true),
+                     ('charlie', 'charlie@co.org', 88.3, false)"
+                ) as &str,
+                &[],
+            )
+            .await
+            .unwrap();
+    }
+
+    println!("Setup complete.\n");
+}
+
+async fn cleanup_database(cfg: &DbConfig) {
+    println!("\nCleaning up...");
+    let client = pg_connect(&regular_conn_string(cfg)).await;
+
+    let drop_slot = format!(
+        "SELECT pg_drop_replication_slot('{SLOT_NAME}') \
+         WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{SLOT_NAME}')"
+    );
+    let _ = client.execute(&drop_slot as &str, &[]).await;
+
+    let _ = client
+        .execute(
+            &format!("DROP PUBLICATION IF EXISTS {PUBLICATION}") as &str,
+            &[],
+        )
+        .await;
+
+    let _ = client
+        .execute(
+            &format!("DROP TABLE IF EXISTS {TABLE_NAME}") as &str,
+            &[],
+        )
+        .await;
+
+    println!("Cleanup done.");
+}
+
+// ---------------------------------------------------------------------------
+// Generate some DML to produce WAL events
+// ---------------------------------------------------------------------------
+
+async fn generate_changes(cfg: &DbConfig) {
+    let client = pg_connect(&regular_conn_string(cfg)).await;
+
+    println!("  Generating INSERT...");
+    client
+        .execute(
+            &format!(
+                "INSERT INTO {TABLE_NAME} (username, email, score, active) \
+                 VALUES ('dave', 'dave@example.com', 45.0, true)"
+            ) as &str,
+            &[],
+        )
+        .await
+        .unwrap();
+
+    println!("  Generating UPDATE...");
+    client
+        .execute(
+            &format!(
+                "UPDATE {TABLE_NAME} SET score = 99.9, email = 'dave.new@example.com' \
+                 WHERE username = 'dave'"
+            ) as &str,
+            &[],
+        )
+        .await
+        .unwrap();
+
+    println!("  Generating DELETE...");
+    client
+        .execute(
+            &format!("DELETE FROM {TABLE_NAME} WHERE username = 'dave'") as &str,
+            &[],
+        )
+        .await
+        .unwrap();
+
+    println!("  DML complete — WAL events should arrive shortly.\n");
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(feature = "rustls-tls")]
+    {
+        let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
+    }
+
+    println!("=== pg-walstream Typed Deserialization (Live DB) ===\n");
+
+    let cfg = parse_db_config();
+    println!(
+        "Target: {}:{}/{} (ssl={})\n",
+        cfg.host, cfg.port, cfg.db, cfg.sslmode
+    );
+
+    // 1. Setup table & publication
+    setup_database(&cfg).await;
+
+    // 2. Start WAL replication stream
+    println!("Starting WAL replication stream...");
+    let stream_config = ReplicationStreamConfig::new(
+        SLOT_NAME.to_string(),
+        PUBLICATION.to_string(),
+        4,
+        StreamingMode::Parallel,
+        Duration::from_secs(5),
+        Duration::from_secs(30),
+        Duration::from_secs(60),
+        RetryConfig::default(),
+    )
+    .with_slot_options(ReplicationSlotOptions {
+        temporary: true,
+        ..Default::default()
+    });
+
+    let mut stream = LogicalReplicationStream::new(&repl_conn_string(&cfg), stream_config).await?;
+    stream.start(None).await?;
+
+    let cancel_token = CancellationToken::new();
+    let cancel_token_clone = cancel_token.clone();
+    let mut event_stream = stream.into_stream(cancel_token.clone());
+
+    // 3. Setup Ctrl+C handler for graceful shutdown
+    tokio::spawn(async move {
+        tokio::signal::ctrl_c().await.ok();
+        println!("\nReceived Ctrl+C, shutting down...");
+        cancel_token_clone.cancel();
+    });
+
+    // 4. Generate some DML in the background so we have events to consume
+    let gen_cfg = cfg.clone();
+    tokio::spawn(async move {
+        generate_changes(&gen_cfg).await;
+    });
+
+    println!("Listening for WAL events... (Press Ctrl+C to stop)\n");
+    println!("{:-<70}", "");
+
+    let mut event_count = 0u64;
+
+    // 5. Event loop — call next_event() and deserialize into User structs
+    loop {
+        match tokio::time::timeout(Duration::from_secs(15), event_stream.next_event()).await {
+            Ok(Ok(event)) => {
+                match &event.event_type {
+                    // ---------------------------------------------------------
+                    // INSERT — deserialize into User
+                    // ---------------------------------------------------------
+                    EventType::Insert { table, .. } => {
+                        match event.deserialize_insert::<User>() {
+                            Ok(user) => {
+                                event_count += 1;
+                                println!(
+                                    "[INSERT] table={table} | User {{ id: {}, username: {:?}, email: {:?}, score: {}, active: {} }}",
+                                    user.id, user.username, user.email, user.score, user.active
+                                );
+                            }
+                            Err(e) => println!("[INSERT] table={table} | deserialize error: {e}"),
+                        }
+                    }
+
+                    // ---------------------------------------------------------
+                    // UPDATE — deserialize old and new into User
+                    // ---------------------------------------------------------
+                    EventType::Update { table, .. } => {
+                        match event.deserialize_update::<User>() {
+                            Ok((old_user, new_user)) => {
+                                event_count += 1;
+                                println!(
+                                    "[UPDATE] table={table} | old={:?} => new=User {{ id: {}, username: {:?}, email: {:?}, score: {}, active: {} }}",
+                                    old_user.map(|u| u.username),
+                                    new_user.id, new_user.username, new_user.email, new_user.score, new_user.active
+                                );
+                            }
+                            Err(e) => println!("[UPDATE] table={table} | deserialize error: {e}"),
+                        }
+                    }
+
+                    // ---------------------------------------------------------
+                    // DELETE — deserialize old row into User
+                    // ---------------------------------------------------------
+                    EventType::Delete { table, .. } => {
+                        match event.deserialize_delete::<User>() {
+                            Ok(user) => {
+                                event_count += 1;
+                                println!(
+                                    "[DELETE] table={table} | User {{ id: {}, username: {:?}, email: {:?}, score: {}, active: {} }}",
+                                    user.id, user.username, user.email, user.score, user.active
+                                );
+                            }
+                            Err(e) => println!("[DELETE] table={table} | deserialize error: {e}"),
+                        }
+                    }
+
+                    // ---------------------------------------------------------
+                    // Transaction boundaries
+                    // ---------------------------------------------------------
+                    EventType::Begin { transaction_id, .. } => {
+                        println!("[BEGIN]  txid={transaction_id}");
+                    }
+                    EventType::Commit { .. } => {
+                        println!("[COMMIT]");
+                        println!("{:-<70}", "");
+                    }
+
+                    // Skip other event types silently
+                    _ => {}
+                }
+
+                event_stream.update_applied_lsn(event.lsn.value());
+            }
+            Ok(Err(e)) => {
+                if matches!(e, pg_walstream::ReplicationError::Cancelled(_)) {
+                    break;
+                }
+                eprintln!("Stream error: {e}");
+                break;
+            }
+            Err(_) => {
+                println!("\nNo more events (15s timeout). Shutting down.");
+                break;
+            }
+        }
+    }
+
+    let _ = event_stream.shutdown().await;
+
+    println!("\nTotal DML events deserialized: {event_count}");
+
+    // 6. Cleanup
+    cleanup_database(&cfg).await;
+
+    println!("\n=== Done ===");
+    Ok(())
+}

--- a/src/column_value.rs
+++ b/src/column_value.rs
@@ -397,6 +397,53 @@ impl RowData {
         self.columns.iter().map(|(k, v)| (k, v))
     }
 
+    /// Access the underlying column slice (crate-internal).
+    #[inline]
+    pub(crate) fn as_columns(&self) -> &[(Arc<str>, ColumnValue)] {
+        &self.columns
+    }
+
+    /// Deserialize this row into a user-defined type.
+    ///
+    /// PostgreSQL sends column values as text strings via the pgoutput plugin.
+    /// This method parses those text values into the fields of `T` using serde
+    /// deserialization with automatic text-to-type coercion.
+    ///
+    /// # Type Coercion
+    ///
+    /// | PostgreSQL text | Rust type |
+    /// |---|---|
+    /// | `"42"` | `i8`, `i16`, `i32`, `i64`, `u8`, `u16`, `u32`, `u64` |
+    /// | `"3.14"` | `f32`, `f64` |
+    /// | `"t"` / `"f"` | `bool` |
+    /// | `"hello"` | `String` |
+    /// | NULL | `Option<T>` (yields `None`) |
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use pg_walstream::{RowData, ColumnValue};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct User {
+    ///     id: u32,
+    ///     name: String,
+    /// }
+    ///
+    /// let row = RowData::from_pairs(vec![
+    ///     ("id", ColumnValue::text("42")),
+    ///     ("name", ColumnValue::text("Alice")),
+    /// ]);
+    ///
+    /// let user: User = row.deserialize_into().unwrap();
+    /// assert_eq!(user.id, 42);
+    /// assert_eq!(user.name, "Alice");
+    /// ```
+    pub fn deserialize_into<T: serde::de::DeserializeOwned>(&self) -> crate::error::Result<T> {
+        T::deserialize(crate::deserializer::RowDataDeserializer::new(self))
+    }
+
     /// Construct from `(&str, ColumnValue)` pairs — handy for tests and literals.
     #[inline]
     pub fn from_pairs(pairs: Vec<(&str, ColumnValue)>) -> Self {

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -1,7 +1,7 @@
-//! Custom serde [`Deserializer`] for converting [`RowData`] into user-defined types.
+//! Custom serde [`Deserializer`][serde::Deserializer] for converting [`RowData`] into user-defined types.
 //!
 //! PostgreSQL's logical replication protocol (pgoutput) sends column values as
-//! text strings. This module provides a [`Deserializer`] that parses those text
+//! text strings. This module provides a [`Deserializer`][serde::Deserializer] that parses those text
 //! representations into the target Rust types automatically.
 //!
 //! # Example
@@ -35,7 +35,7 @@ use std::sync::Arc;
 // RowDataDeserializer — top-level Deserializer for RowData
 // ---------------------------------------------------------------------------
 
-/// A serde [`Deserializer`] that treats a [`RowData`] as a map of column names
+/// A serde [`Deserializer`][serde::Deserializer] that treats a [`RowData`] as a map of column names
 /// to values and deserializes it into a user-defined struct.
 pub struct RowDataDeserializer<'a> {
     row: &'a RowData,
@@ -1606,5 +1606,181 @@ mod tests {
         // HashMap triggers deserialize_map, which goes through deserialize_any fallback path
         let m: HashMap<String, String> = HashMap::deserialize(de).unwrap();
         assert_eq!(m.get("k").unwrap(), "v");
+    }
+
+    // -- Invalid UTF-8 in Text column ----------------------------------------
+
+    #[test]
+    fn test_invalid_utf8_text_as_string_errors() {
+        // Text column containing invalid UTF-8 (lone continuation byte)
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            (
+                "username",
+                ColumnValue::Text(Bytes::from_static(&[0xff, 0xfe])),
+            ),
+        ]);
+        let result: crate::error::Result<UserModel> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("invalid UTF-8"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_invalid_utf8_text_as_numeric_errors() {
+        let row = RowData::from_pairs(vec![(
+            "val",
+            ColumnValue::Text(Bytes::from_static(&[0xff, 0xfe])),
+        )]);
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            val: u32,
+        }
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("invalid UTF-8"), "got: {msg}");
+    }
+
+    // -- deserialize_any: Binary and invalid-UTF8 Text fallbacks -------------
+
+    #[test]
+    fn test_any_binary_via_bytebuf_hashmap() {
+        // HashMap<String, serde_bytes::ByteBuf> triggers deserialize_any on columns;
+        // Binary column hits the Binary → visit_bytes branch.
+        use std::collections::HashMap;
+        let row = RowData::from_pairs(vec![(
+            "blob",
+            ColumnValue::binary_bytes(Bytes::from_static(&[0x01, 0x02, 0x03])),
+        )]);
+        let m: HashMap<String, serde_bytes::ByteBuf> = row.deserialize_into().unwrap();
+        assert_eq!(m.get("blob").unwrap().as_ref(), &[0x01, 0x02, 0x03]);
+    }
+
+    #[test]
+    fn test_any_invalid_utf8_text_via_bytebuf_hashmap() {
+        // Invalid-UTF8 Text column hits the Text → visit_bytes fallback in deserialize_any.
+        use std::collections::HashMap;
+        let row = RowData::from_pairs(vec![(
+            "blob",
+            ColumnValue::Text(Bytes::from_static(&[0xff, 0xfe, 0xfd])),
+        )]);
+        let m: HashMap<String, serde_bytes::ByteBuf> = row.deserialize_into().unwrap();
+        assert_eq!(m.get("blob").unwrap().as_ref(), &[0xff, 0xfe, 0xfd]);
+    }
+
+    // -- deserialize_byte_buf Text path ---------------------------------------
+
+    #[test]
+    fn test_byte_buf_from_text() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            #[serde(with = "serde_bytes")]
+            data: Vec<u8>,
+        }
+        let row = RowData::from_pairs(vec![("data", ColumnValue::text("hello"))]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.data, b"hello");
+    }
+
+    // -- Non-unit enum variants: hit UnitVariantAccess error paths ------------
+
+    #[test]
+    fn test_enum_newtype_variant_not_supported() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            #[allow(dead_code)]
+            V(u32),
+        }
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            e: E,
+        }
+        let row = RowData::from_pairs(vec![("e", ColumnValue::text("V"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("newtype"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_enum_tuple_variant_not_supported() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            #[allow(dead_code)]
+            V(u32, u32),
+        }
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            e: E,
+        }
+        let row = RowData::from_pairs(vec![("e", ColumnValue::text("V"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("tuple"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_enum_struct_variant_not_supported() {
+        #[derive(Debug, Deserialize)]
+        enum E {
+            #[allow(dead_code)]
+            V { x: u32 },
+        }
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            e: E,
+        }
+        let row = RowData::from_pairs(vec![("e", ColumnValue::text("V"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("struct"), "got: {msg}");
+    }
+
+    // -- Multi-byte char -------------------------------------------------------
+
+    #[test]
+    fn test_char_multibyte_unicode() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            c: char,
+        }
+        let row = RowData::from_pairs(vec![("c", ColumnValue::text("é"))]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.c, 'é');
+    }
+
+    // -- Option wrapping numeric none path ------------------------------------
+
+    #[test]
+    fn test_option_u64_none() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            val: Option<u64>,
+        }
+        let row = RowData::from_pairs(vec![("val", ColumnValue::Null)]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.val, None);
+    }
+
+    // -- deserialize_str via &str target --------------------------------------
+
+    #[test]
+    fn test_str_field() {
+        // String already covered; this exercises deserialize_str path explicitly
+        // via a type that calls deserialize_str during Visitor expectation.
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            name: String,
+        }
+        let row = RowData::from_pairs(vec![("name", ColumnValue::text("alice"))]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.name, "alice");
     }
 }

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -1,0 +1,1610 @@
+//! Custom serde [`Deserializer`] for converting [`RowData`] into user-defined types.
+//!
+//! PostgreSQL's logical replication protocol (pgoutput) sends column values as
+//! text strings. This module provides a [`Deserializer`] that parses those text
+//! representations into the target Rust types automatically.
+//!
+//! # Example
+//!
+//! ```
+//! use pg_walstream::{RowData, ColumnValue};
+//! use serde::Deserialize;
+//!
+//! #[derive(Deserialize, Debug, PartialEq)]
+//! struct User {
+//!     id: u32,
+//!     username: String,
+//! }
+//!
+//! let row = RowData::from_pairs(vec![
+//!     ("id", ColumnValue::text("42")),
+//!     ("username", ColumnValue::text("alice")),
+//! ]);
+//!
+//! let user: User = row.deserialize_into().unwrap();
+//! assert_eq!(user.id, 42);
+//! assert_eq!(user.username, "alice");
+//! ```
+
+use crate::column_value::{ColumnValue, RowData};
+use crate::error::ReplicationError;
+use serde::de::{self, DeserializeSeed, MapAccess, Visitor};
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// RowDataDeserializer — top-level Deserializer for RowData
+// ---------------------------------------------------------------------------
+
+/// A serde [`Deserializer`] that treats a [`RowData`] as a map of column names
+/// to values and deserializes it into a user-defined struct.
+pub struct RowDataDeserializer<'a> {
+    row: &'a RowData,
+}
+
+impl<'a> RowDataDeserializer<'a> {
+    /// Create a new deserializer from a [`RowData`] reference.
+    pub fn new(row: &'a RowData) -> Self {
+        Self { row }
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for RowDataDeserializer<'a> {
+    type Error = ReplicationError;
+
+    #[inline]
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_map(visitor)
+    }
+
+    #[inline]
+    fn deserialize_map<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let columns = self.row.as_columns();
+        let map = RowDataMapAccess {
+            iter: columns.iter(),
+            current_value: None,
+        };
+        visitor.visit_map(map)
+    }
+
+    #[inline]
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_map(visitor)
+    }
+
+    // Forward all other types to deserialize_any since RowData is fundamentally a map.
+    serde::forward_to_deserialize_any! {
+        bool i8 i16 i32 i64 u8 u16 u32 u64 f32 f64 char str string
+        bytes byte_buf option unit unit_struct newtype_struct seq tuple
+        tuple_struct enum identifier ignored_any
+    }
+}
+
+// ---------------------------------------------------------------------------
+// RowDataMapAccess — iterates over RowData columns as map entries
+// ---------------------------------------------------------------------------
+
+struct RowDataMapAccess<'a> {
+    iter: std::slice::Iter<'a, (Arc<str>, ColumnValue)>,
+    current_value: Option<&'a ColumnValue>,
+}
+
+impl<'de, 'a> MapAccess<'de> for RowDataMapAccess<'a> {
+    type Error = ReplicationError;
+
+    #[inline]
+    fn next_key_seed<K: DeserializeSeed<'de>>(
+        &mut self,
+        seed: K,
+    ) -> Result<Option<K::Value>, Self::Error> {
+        match self.iter.next() {
+            Some((key, value)) => {
+                self.current_value = Some(value);
+                let key_de = serde::de::value::StrDeserializer::new(key.as_ref());
+                seed.deserialize(key_de).map(Some)
+            }
+            None => Ok(None),
+        }
+    }
+
+    #[inline]
+    fn next_value_seed<V: DeserializeSeed<'de>>(
+        &mut self,
+        seed: V,
+    ) -> Result<V::Value, Self::Error> {
+        let value = self
+            .current_value
+            .take()
+            .expect("next_value_seed called before next_key_seed");
+        seed.deserialize(ColumnValueDeserializer { value })
+    }
+
+    #[inline]
+    fn size_hint(&self) -> Option<usize> {
+        let (lower, upper) = self.iter.size_hint();
+        Some(upper.unwrap_or(lower))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// ColumnValueDeserializer — deserializes a single ColumnValue
+// ---------------------------------------------------------------------------
+
+struct ColumnValueDeserializer<'a> {
+    value: &'a ColumnValue,
+}
+
+impl<'a> ColumnValueDeserializer<'a> {
+    /// Get the text content or return an error for the given target type.
+    #[inline]
+    fn text_or_err(&self, target: &str) -> Result<&'a str, ReplicationError> {
+        match self.value {
+            ColumnValue::Text(b) => std::str::from_utf8(b).map_err(|e| {
+                ReplicationError::deserialize(format!("invalid UTF-8 for {target}: {e}"))
+            }),
+            ColumnValue::Null => Err(ReplicationError::deserialize(format!(
+                "cannot deserialize NULL as {target} (use Option<{target}>)"
+            ))),
+            ColumnValue::Binary(_) => Err(ReplicationError::deserialize(format!(
+                "cannot deserialize binary column as {target}"
+            ))),
+        }
+    }
+
+    /// Parse text as a numeric type.
+    #[inline]
+    fn parse_text<T: std::str::FromStr>(&self, type_name: &str) -> Result<T, ReplicationError>
+    where
+        T::Err: std::fmt::Display,
+    {
+        let s = self.text_or_err(type_name)?;
+        s.parse::<T>().map_err(|e| {
+            ReplicationError::deserialize(format!(
+                "failed to parse '{}' as {}: {}",
+                s, type_name, e
+            ))
+        })
+    }
+}
+
+impl<'de, 'a> de::Deserializer<'de> for ColumnValueDeserializer<'a> {
+    type Error = ReplicationError;
+
+    #[inline]
+    fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value {
+            ColumnValue::Null => visitor.visit_none(),
+            ColumnValue::Text(b) => match std::str::from_utf8(b) {
+                Ok(s) => visitor.visit_str(s),
+                Err(_) => visitor.visit_bytes(b),
+            },
+            ColumnValue::Binary(b) => visitor.visit_bytes(b),
+        }
+    }
+
+    #[inline]
+    fn deserialize_bool<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let s = self.text_or_err("bool")?;
+        // Fast path: PostgreSQL's pgoutput always sends "t"/"f" for booleans.
+        // Check single-byte values first (covers ~99% of real WAL traffic),
+        // then fall through to full PostgreSQL boolean input vocabulary.
+        let val = if s.len() == 1 {
+            match s.as_bytes()[0] {
+                b't' | b'1' => true,
+                b'f' | b'0' => false,
+                _ => {
+                    return Err(ReplicationError::deserialize(format!(
+                        "cannot parse '{s}' as bool (expected t/f/true/false/1/0/on/off/yes/no)"
+                    )))
+                }
+            }
+        } else {
+            match s {
+                "true" | "on" | "yes" => true,
+                "false" | "off" | "no" => false,
+                _ => {
+                    return Err(ReplicationError::deserialize(format!(
+                        "cannot parse '{s}' as bool (expected t/f/true/false/1/0/on/off/yes/no)"
+                    )))
+                }
+            }
+        };
+        visitor.visit_bool(val)
+    }
+
+    #[inline]
+    fn deserialize_i8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i8(self.parse_text("i8")?)
+    }
+
+    #[inline]
+    fn deserialize_i16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i16(self.parse_text("i16")?)
+    }
+
+    #[inline]
+    fn deserialize_i32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i32(self.parse_text("i32")?)
+    }
+
+    #[inline]
+    fn deserialize_i64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_i64(self.parse_text("i64")?)
+    }
+
+    #[inline]
+    fn deserialize_u8<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u8(self.parse_text("u8")?)
+    }
+
+    #[inline]
+    fn deserialize_u16<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u16(self.parse_text("u16")?)
+    }
+
+    #[inline]
+    fn deserialize_u32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u32(self.parse_text("u32")?)
+    }
+
+    #[inline]
+    fn deserialize_u64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_u64(self.parse_text("u64")?)
+    }
+
+    #[inline]
+    fn deserialize_f32<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_f32(self.parse_text("f32")?)
+    }
+
+    #[inline]
+    fn deserialize_f64<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_f64(self.parse_text("f64")?)
+    }
+
+    #[inline]
+    fn deserialize_char<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let s = self.text_or_err("char")?;
+        let mut chars = s.chars();
+        match (chars.next(), chars.next()) {
+            (Some(c), None) => visitor.visit_char(c),
+            _ => Err(ReplicationError::deserialize(format!(
+                "expected single char, got '{s}'"
+            ))),
+        }
+    }
+
+    #[inline]
+    fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let s = self.text_or_err("str")?;
+        visitor.visit_str(s)
+    }
+
+    #[inline]
+    fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        let s = self.text_or_err("String")?;
+        visitor.visit_str(s)
+    }
+
+    #[inline]
+    fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value {
+            ColumnValue::Binary(b) => visitor.visit_bytes(b),
+            ColumnValue::Text(b) => visitor.visit_bytes(b),
+            ColumnValue::Null => Err(ReplicationError::deserialize(
+                "cannot deserialize NULL as bytes",
+            )),
+        }
+    }
+
+    #[inline]
+    fn deserialize_byte_buf<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value {
+            ColumnValue::Binary(b) => visitor.visit_byte_buf(b.to_vec()),
+            ColumnValue::Text(b) => visitor.visit_byte_buf(b.to_vec()),
+            ColumnValue::Null => Err(ReplicationError::deserialize(
+                "cannot deserialize NULL as byte_buf",
+            )),
+        }
+    }
+
+    #[inline]
+    fn deserialize_option<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value {
+            ColumnValue::Null => visitor.visit_none(),
+            _ => visitor.visit_some(self),
+        }
+    }
+
+    #[inline]
+    fn deserialize_unit<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        match self.value {
+            ColumnValue::Null => visitor.visit_unit(),
+            _ => Err(ReplicationError::deserialize("expected NULL for unit type")),
+        }
+    }
+
+    #[inline]
+    fn deserialize_unit_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        self.deserialize_unit(visitor)
+    }
+
+    #[inline]
+    fn deserialize_newtype_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        visitor.visit_newtype_struct(self)
+    }
+
+    #[inline]
+    fn deserialize_seq<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(ReplicationError::deserialize(
+            "sequences are not supported in RowData deserialization",
+        ))
+    }
+
+    #[inline]
+    fn deserialize_tuple<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(ReplicationError::deserialize(
+            "tuples are not supported in RowData deserialization",
+        ))
+    }
+
+    #[inline]
+    fn deserialize_tuple_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(ReplicationError::deserialize(
+            "tuple structs are not supported in RowData deserialization",
+        ))
+    }
+
+    #[inline]
+    fn deserialize_map<V: Visitor<'de>>(self, _visitor: V) -> Result<V::Value, Self::Error> {
+        Err(ReplicationError::deserialize(
+            "nested maps are not supported in RowData deserialization",
+        ))
+    }
+
+    #[inline]
+    fn deserialize_struct<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(ReplicationError::deserialize(
+            "nested structs are not supported in RowData deserialization",
+        ))
+    }
+
+    #[inline]
+    fn deserialize_enum<V: Visitor<'de>>(
+        self,
+        _name: &'static str,
+        _variants: &'static [&'static str],
+        visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        let s = self.text_or_err("enum")?;
+        visitor.visit_enum(s.into_deserializer())
+    }
+
+    #[inline]
+    fn deserialize_identifier<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        self.deserialize_str(visitor)
+    }
+
+    #[inline]
+    fn deserialize_ignored_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
+        visitor.visit_unit()
+    }
+}
+
+/// Helper to convert `&str` into a serde enum deserializer.
+struct StrEnumAccess<'a>(&'a str);
+
+impl<'de, 'a> de::EnumAccess<'de> for StrEnumAccess<'a> {
+    type Error = ReplicationError;
+    type Variant = UnitVariantAccess;
+
+    fn variant_seed<V: DeserializeSeed<'de>>(
+        self,
+        seed: V,
+    ) -> Result<(V::Value, Self::Variant), Self::Error> {
+        let de: serde::de::value::StrDeserializer<'_, ReplicationError> =
+            serde::de::value::StrDeserializer::new(self.0);
+        let val = seed.deserialize(de)?;
+        Ok((val, UnitVariantAccess))
+    }
+}
+
+struct UnitVariantAccess;
+
+impl<'de> de::VariantAccess<'de> for UnitVariantAccess {
+    type Error = ReplicationError;
+
+    fn unit_variant(self) -> Result<(), Self::Error> {
+        Ok(())
+    }
+
+    fn newtype_variant_seed<T: DeserializeSeed<'de>>(
+        self,
+        _seed: T,
+    ) -> Result<T::Value, Self::Error> {
+        Err(ReplicationError::deserialize(
+            "newtype enum variants are not supported",
+        ))
+    }
+
+    fn tuple_variant<V: Visitor<'de>>(
+        self,
+        _len: usize,
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(ReplicationError::deserialize(
+            "tuple enum variants are not supported",
+        ))
+    }
+
+    fn struct_variant<V: Visitor<'de>>(
+        self,
+        _fields: &'static [&'static str],
+        _visitor: V,
+    ) -> Result<V::Value, Self::Error> {
+        Err(ReplicationError::deserialize(
+            "struct enum variants are not supported",
+        ))
+    }
+}
+
+/// Trait extension to convert `&str` into an `EnumAccess` deserializer.
+trait IntoEnumDeserializer<'a> {
+    fn into_deserializer(self) -> StrEnumAccess<'a>;
+}
+
+impl<'a> IntoEnumDeserializer<'a> for &'a str {
+    fn into_deserializer(self) -> StrEnumAccess<'a> {
+        StrEnumAccess(self)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::column_value::{ColumnValue, RowData};
+    use crate::types::{ChangeEvent, Lsn, ReplicaIdentity};
+    use bytes::Bytes;
+    use serde::Deserialize;
+    use std::sync::Arc;
+
+    // -- Basic struct deserialization -----------------------------------------
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct UserModel {
+        id: u32,
+        username: String,
+    }
+
+    #[test]
+    fn test_basic_struct() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("42")),
+            ("username", ColumnValue::text("alice")),
+        ]);
+        let user: UserModel = row.deserialize_into().unwrap();
+        assert_eq!(user.id, 42);
+        assert_eq!(user.username, "alice");
+    }
+
+    // -- All numeric types ---------------------------------------------------
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct AllNumerics {
+        a_i8: i8,
+        a_i16: i16,
+        a_i32: i32,
+        a_i64: i64,
+        a_u8: u8,
+        a_u16: u16,
+        a_u32: u32,
+        a_u64: u64,
+        a_f32: f32,
+        a_f64: f64,
+    }
+
+    #[test]
+    fn test_all_numeric_types() {
+        let row = RowData::from_pairs(vec![
+            ("a_i8", ColumnValue::text("-1")),
+            ("a_i16", ColumnValue::text("-200")),
+            ("a_i32", ColumnValue::text("-300000")),
+            ("a_i64", ColumnValue::text("-4000000000")),
+            ("a_u8", ColumnValue::text("255")),
+            ("a_u16", ColumnValue::text("65535")),
+            ("a_u32", ColumnValue::text("4294967295")),
+            ("a_u64", ColumnValue::text("18446744073709551615")),
+            ("a_f32", ColumnValue::text("1.5")),
+            ("a_f64", ColumnValue::text("2.5")),
+        ]);
+        let v: AllNumerics = row.deserialize_into().unwrap();
+        assert_eq!(v.a_i8, -1);
+        assert_eq!(v.a_i16, -200);
+        assert_eq!(v.a_i32, -300000);
+        assert_eq!(v.a_i64, -4000000000);
+        assert_eq!(v.a_u8, 255);
+        assert_eq!(v.a_u16, 65535);
+        assert_eq!(v.a_u32, 4294967295);
+        assert_eq!(v.a_u64, 18446744073709551615);
+        assert!((v.a_f32 - 1.5).abs() < 0.001);
+        assert!((v.a_f64 - 2.5).abs() < 0.0000001);
+    }
+
+    // -- Boolean parsing (PostgreSQL sends "t"/"f") --------------------------
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Booleans {
+        a: bool,
+        b: bool,
+        c: bool,
+        d: bool,
+        e: bool,
+        f: bool,
+    }
+
+    #[test]
+    fn test_boolean_parsing() {
+        let row = RowData::from_pairs(vec![
+            ("a", ColumnValue::text("t")),
+            ("b", ColumnValue::text("f")),
+            ("c", ColumnValue::text("true")),
+            ("d", ColumnValue::text("false")),
+            ("e", ColumnValue::text("1")),
+            ("f", ColumnValue::text("0")),
+        ]);
+        let v: Booleans = row.deserialize_into().unwrap();
+        assert!(v.a);
+        assert!(!v.b);
+        assert!(v.c);
+        assert!(!v.d);
+        assert!(v.e);
+        assert!(!v.f);
+    }
+
+    #[test]
+    fn test_boolean_invalid() {
+        let row = RowData::from_pairs(vec![("a", ColumnValue::text("maybe"))]);
+        #[derive(Debug, Deserialize)]
+        struct B {
+            #[allow(dead_code)]
+            a: bool,
+        }
+        let result: crate::error::Result<B> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("maybe"), "got: {msg}");
+    }
+
+    // -- PostgreSQL full boolean input vocabulary --------------------------------
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct BoolExtended {
+        a: bool,
+        b: bool,
+        c: bool,
+        d: bool,
+    }
+
+    #[test]
+    fn test_boolean_on_off_yes_no() {
+        let row = RowData::from_pairs(vec![
+            ("a", ColumnValue::text("on")),
+            ("b", ColumnValue::text("off")),
+            ("c", ColumnValue::text("yes")),
+            ("d", ColumnValue::text("no")),
+        ]);
+        let v: BoolExtended = row.deserialize_into().unwrap();
+        assert!(v.a);
+        assert!(!v.b);
+        assert!(v.c);
+        assert!(!v.d);
+    }
+
+    // -- Option fields (nullable columns) ------------------------------------
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct WithOptions {
+        id: u32,
+        name: Option<String>,
+        score: Option<f64>,
+    }
+
+    #[test]
+    fn test_option_some() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("name", ColumnValue::text("alice")),
+            ("score", ColumnValue::text("99.5")),
+        ]);
+        let v: WithOptions = row.deserialize_into().unwrap();
+        assert_eq!(v.id, 1);
+        assert_eq!(v.name, Some("alice".to_string()));
+        assert_eq!(v.score, Some(99.5));
+    }
+
+    #[test]
+    fn test_option_none() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("name", ColumnValue::Null),
+            ("score", ColumnValue::Null),
+        ]);
+        let v: WithOptions = row.deserialize_into().unwrap();
+        assert_eq!(v.id, 1);
+        assert_eq!(v.name, None);
+        assert_eq!(v.score, None);
+    }
+
+    // -- Error cases ---------------------------------------------------------
+
+    #[test]
+    fn test_null_into_non_option() {
+        let row = RowData::from_pairs(vec![("id", ColumnValue::Null)]);
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            id: u32,
+        }
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("NULL"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_type_mismatch() {
+        let row = RowData::from_pairs(vec![("id", ColumnValue::text("not_a_number"))]);
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            id: u32,
+        }
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("not_a_number"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_overflow() {
+        let row = RowData::from_pairs(vec![("val", ColumnValue::text("99999"))]);
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            val: i8,
+        }
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+    }
+
+    // -- Extra columns ignored -----------------------------------------------
+
+    #[test]
+    fn test_extra_columns_ignored() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("bob")),
+            ("extra_col", ColumnValue::text("ignored")),
+        ]);
+        let user: UserModel = row.deserialize_into().unwrap();
+        assert_eq!(user.id, 1);
+        assert_eq!(user.username, "bob");
+    }
+
+    // -- Serde attributes ----------------------------------------------------
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct Renamed {
+        #[serde(rename = "user_id")]
+        id: u32,
+        #[serde(rename = "user_name")]
+        name: String,
+    }
+
+    #[test]
+    fn test_serde_rename() {
+        let row = RowData::from_pairs(vec![
+            ("user_id", ColumnValue::text("10")),
+            ("user_name", ColumnValue::text("charlie")),
+        ]);
+        let v: Renamed = row.deserialize_into().unwrap();
+        assert_eq!(v.id, 10);
+        assert_eq!(v.name, "charlie");
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct WithDefaults {
+        id: u32,
+        #[serde(default)]
+        count: u32,
+        #[serde(default = "default_name")]
+        name: String,
+    }
+
+    fn default_name() -> String {
+        "unknown".to_string()
+    }
+
+    #[test]
+    fn test_serde_default() {
+        let row = RowData::from_pairs(vec![("id", ColumnValue::text("5"))]);
+        let v: WithDefaults = row.deserialize_into().unwrap();
+        assert_eq!(v.id, 5);
+        assert_eq!(v.count, 0);
+        assert_eq!(v.name, "unknown");
+    }
+
+    // -- Char deserialization ------------------------------------------------
+
+    #[test]
+    fn test_char_field() {
+        #[derive(Deserialize, PartialEq, Debug)]
+        struct S {
+            c: char,
+        }
+        let row = RowData::from_pairs(vec![("c", ColumnValue::text("A"))]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.c, 'A');
+    }
+
+    #[test]
+    fn test_char_too_long() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            c: char,
+        }
+        let row = RowData::from_pairs(vec![("c", ColumnValue::text("AB"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+    }
+
+    // -- Enum deserialization (simple unit variants) -------------------------
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    enum Status {
+        Active,
+        Inactive,
+    }
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct WithEnum {
+        id: u32,
+        status: Status,
+    }
+
+    #[test]
+    fn test_enum_unit_variant() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("status", ColumnValue::text("Active")),
+        ]);
+        let v: WithEnum = row.deserialize_into().unwrap();
+        assert_eq!(v.id, 1);
+        assert_eq!(v.status, Status::Active);
+    }
+
+    // -- Binary columns ------------------------------------------------------
+
+    #[test]
+    fn test_binary_column_to_string_errors() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            (
+                "username",
+                ColumnValue::binary_bytes(Bytes::from_static(b"binary")),
+            ),
+        ]);
+        let result: crate::error::Result<UserModel> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("binary"), "got: {msg}");
+    }
+
+    // -- ChangeEvent convenience methods -------------------------------------
+
+    #[test]
+    fn test_deserialize_insert() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("alice")),
+        ]);
+        let event = ChangeEvent::insert("public", "users", 1, row, Lsn::new(100));
+        let user: UserModel = event.deserialize_insert().unwrap();
+        assert_eq!(user.id, 1);
+        assert_eq!(user.username, "alice");
+    }
+
+    #[test]
+    fn test_deserialize_insert_wrong_event() {
+        let ts = chrono::Utc::now();
+        let event = ChangeEvent::begin(1, Lsn::new(100), ts, Lsn::new(100));
+        let result: crate::error::Result<UserModel> = event.deserialize_insert();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("begin"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_deserialize_update_both() {
+        let old = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("alice")),
+        ]);
+        let new = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("bob")),
+        ]);
+        let event = ChangeEvent::update(
+            "public",
+            "users",
+            1,
+            Some(old),
+            new,
+            ReplicaIdentity::Full,
+            vec![Arc::from("id")],
+            Lsn::new(200),
+        );
+        let (old, new): (Option<UserModel>, UserModel) = event.deserialize_update().unwrap();
+        assert_eq!(old.unwrap().username, "alice");
+        assert_eq!(new.username, "bob");
+    }
+
+    #[test]
+    fn test_deserialize_update_both_no_old() {
+        let new = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("bob")),
+        ]);
+        let event = ChangeEvent::update(
+            "public",
+            "users",
+            1,
+            None,
+            new,
+            ReplicaIdentity::Default,
+            vec![Arc::from("id")],
+            Lsn::new(200),
+        );
+        let (old, new): (Option<UserModel>, UserModel) = event.deserialize_update().unwrap();
+        assert!(old.is_none());
+        assert_eq!(new.username, "bob");
+    }
+
+    #[test]
+    fn test_deserialize_update_both_wrong_event() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("alice")),
+        ]);
+        let event = ChangeEvent::insert("public", "users", 1, row, Lsn::new(100));
+        let result: crate::error::Result<(Option<UserModel>, UserModel)> =
+            event.deserialize_update();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_deserialize_delete() {
+        let old = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("alice")),
+        ]);
+        let event = ChangeEvent::delete(
+            "public",
+            "users",
+            1,
+            old,
+            ReplicaIdentity::Full,
+            vec![Arc::from("id")],
+            Lsn::new(300),
+        );
+        let user: UserModel = event.deserialize_delete().unwrap();
+        assert_eq!(user.id, 1);
+        assert_eq!(user.username, "alice");
+    }
+
+    #[test]
+    fn test_deserialize_data_for_all_dml() {
+        // Insert
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("alice")),
+        ]);
+        let event = ChangeEvent::insert("public", "users", 1, row, Lsn::new(100));
+        let user: UserModel = event.deserialize_data().unwrap();
+        assert_eq!(user.username, "alice");
+
+        // Update
+        let new = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("2")),
+            ("username", ColumnValue::text("bob")),
+        ]);
+        let event = ChangeEvent::update(
+            "public",
+            "users",
+            1,
+            None,
+            new,
+            ReplicaIdentity::Default,
+            vec![],
+            Lsn::new(200),
+        );
+        let user: UserModel = event.deserialize_data().unwrap();
+        assert_eq!(user.username, "bob");
+
+        // Delete
+        let old = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("3")),
+            ("username", ColumnValue::text("charlie")),
+        ]);
+        let event = ChangeEvent::delete(
+            "public",
+            "users",
+            1,
+            old,
+            ReplicaIdentity::Full,
+            vec![],
+            Lsn::new(300),
+        );
+        let user: UserModel = event.deserialize_data().unwrap();
+        assert_eq!(user.username, "charlie");
+    }
+
+    #[test]
+    fn test_deserialize_data_non_dml_errors() {
+        let ts = chrono::Utc::now();
+        let event = ChangeEvent::begin(1, Lsn::new(100), ts, Lsn::new(100));
+        let result: crate::error::Result<UserModel> = event.deserialize_data();
+        assert!(result.is_err());
+    }
+
+    // -- Empty RowData -------------------------------------------------------
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct AllOptional {
+        #[serde(default)]
+        id: Option<u32>,
+        #[serde(default)]
+        name: Option<String>,
+    }
+
+    #[test]
+    fn test_empty_row_with_defaults() {
+        let row = RowData::new();
+        let v: AllOptional = row.deserialize_into().unwrap();
+        assert_eq!(v.id, None);
+        assert_eq!(v.name, None);
+    }
+
+    // -- Newtype struct ------------------------------------------------------
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct UserId(u32);
+
+    #[derive(Debug, Deserialize, PartialEq)]
+    struct WithNewtype {
+        id: UserId,
+        name: String,
+    }
+
+    #[test]
+    fn test_newtype_struct() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("42")),
+            ("name", ColumnValue::text("alice")),
+        ]);
+        let v: WithNewtype = row.deserialize_into().unwrap();
+        assert_eq!(v.id, UserId(42));
+        assert_eq!(v.name, "alice");
+    }
+
+    // -- Empty string --------------------------------------------------------
+
+    #[test]
+    fn test_empty_string_field() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("")),
+        ]);
+        let user: UserModel = row.deserialize_into().unwrap();
+        assert_eq!(user.id, 1);
+        assert_eq!(user.username, "");
+    }
+
+    // -- Binary bytes / byte_buf deserialization ------------------------------
+
+    #[test]
+    fn test_bytes_from_binary_column() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            #[serde(with = "serde_bytes")]
+            data: Vec<u8>,
+        }
+        let row = RowData::from_pairs(vec![(
+            "data",
+            ColumnValue::binary_bytes(Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef])),
+        )]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.data, vec![0xde, 0xad, 0xbe, 0xef]);
+    }
+
+    #[test]
+    fn test_bytes_from_text_column() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            #[serde(with = "serde_bytes")]
+            data: Vec<u8>,
+        }
+        let row = RowData::from_pairs(vec![("data", ColumnValue::text("hello"))]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.data, b"hello");
+    }
+
+    #[test]
+    fn test_bytes_null_errors() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[serde(with = "serde_bytes")]
+            #[allow(dead_code)]
+            data: Vec<u8>,
+        }
+        let row = RowData::from_pairs(vec![("data", ColumnValue::Null)]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("NULL"), "got: {msg}");
+    }
+
+    // -- deserialize_any paths -----------------------------------------------
+
+    #[test]
+    fn test_deserialize_any_null() {
+        // deserialize_any on Null visits none, which works for Option<T>
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            #[serde(default)]
+            val: Option<String>,
+        }
+        let row = RowData::from_pairs(vec![("val", ColumnValue::Null)]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.val, None);
+    }
+
+    #[test]
+    fn test_deserialize_any_binary() {
+        // deserialize_any on Binary visits bytes; test the path indirectly
+        // through ignored_any (extra columns with binary data are skipped)
+        let row = RowData::from_pairs(vec![
+            ("a", ColumnValue::text("hello")),
+            ("b", ColumnValue::binary_bytes(Bytes::from_static(&[0x01]))),
+        ]);
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            a: String,
+        }
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.a, "hello");
+    }
+
+    // -- Unit / unit_struct deserialization -----------------------------------
+
+    #[test]
+    fn test_unit_from_null() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            val: (),
+        }
+        let row = RowData::from_pairs(vec![("val", ColumnValue::Null)]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.val, ());
+    }
+
+    #[test]
+    fn test_unit_from_non_null_errors() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            val: (),
+        }
+        let row = RowData::from_pairs(vec![("val", ColumnValue::text("something"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("NULL"), "got: {msg}");
+    }
+
+    // -- Unsupported type errors (seq, tuple, tuple_struct, map, struct on column) --
+
+    #[test]
+    fn test_seq_not_supported() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            vals: Vec<u32>,
+        }
+        let row = RowData::from_pairs(vec![("vals", ColumnValue::text("[1,2,3]"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("sequence"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_nested_struct_not_supported() {
+        #[derive(Debug, Deserialize)]
+        struct Inner {
+            #[allow(dead_code)]
+            x: u32,
+        }
+        #[derive(Debug, Deserialize)]
+        struct Outer {
+            #[allow(dead_code)]
+            inner: Inner,
+        }
+        let row = RowData::from_pairs(vec![("inner", ColumnValue::text("{\"x\":1}"))]);
+        let result: crate::error::Result<Outer> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("nested struct"), "got: {msg}");
+    }
+
+    // -- text_or_err error paths (NULL for bool, Binary for numeric) ----------
+
+    #[test]
+    fn test_null_bool_errors() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            flag: bool,
+        }
+        let row = RowData::from_pairs(vec![("flag", ColumnValue::Null)]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("NULL"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_binary_numeric_errors() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            val: i32,
+        }
+        let row = RowData::from_pairs(vec![(
+            "val",
+            ColumnValue::binary_bytes(Bytes::from_static(&[0x01, 0x02])),
+        )]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("binary"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_binary_bool_errors() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            flag: bool,
+        }
+        let row = RowData::from_pairs(vec![(
+            "flag",
+            ColumnValue::binary_bytes(Bytes::from_static(&[0x01])),
+        )]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("binary"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_binary_string_errors() {
+        let row = RowData::from_pairs(vec![(
+            "username",
+            ColumnValue::binary_bytes(Bytes::from_static(b"data")),
+        )]);
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            username: String,
+        }
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("binary"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_null_string_errors() {
+        let row = RowData::from_pairs(vec![("name", ColumnValue::Null)]);
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            name: String,
+        }
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("NULL"), "got: {msg}");
+    }
+
+    // -- Char edge cases -----------------------------------------------------
+
+    #[test]
+    fn test_char_empty_string_errors() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            c: char,
+        }
+        let row = RowData::from_pairs(vec![("c", ColumnValue::text(""))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_char_null_errors() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            c: char,
+        }
+        let row = RowData::from_pairs(vec![("c", ColumnValue::Null)]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+    }
+
+    // -- Enum edge cases ----------------------------------------------------
+
+    #[test]
+    fn test_enum_unknown_variant_errors() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("status", ColumnValue::text("Unknown")),
+        ]);
+        let result: crate::error::Result<WithEnum> = row.deserialize_into();
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_enum_null_errors() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("status", ColumnValue::Null),
+        ]);
+        let result: crate::error::Result<WithEnum> = row.deserialize_into();
+        assert!(result.is_err());
+    }
+
+    // -- ChangeEvent wrong-event-type errors ---------------------------------
+
+    #[test]
+    fn test_deserialize_delete_wrong_event() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("username", ColumnValue::text("alice")),
+        ]);
+        let event = ChangeEvent::insert("public", "users", 1, row, Lsn::new(100));
+        let result: crate::error::Result<UserModel> = event.deserialize_delete();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("insert"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_deserialize_data_truncate_errors() {
+        let event = ChangeEvent::truncate(vec![Arc::from("public.users")], Lsn::new(100));
+        let result: crate::error::Result<UserModel> = event.deserialize_data();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("truncate"), "got: {msg}");
+    }
+
+    // -- Option<bool> and Option<i32> (Option wrapping non-string types) -----
+
+    #[test]
+    fn test_option_bool_some() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            flag: Option<bool>,
+        }
+        let row = RowData::from_pairs(vec![("flag", ColumnValue::text("t"))]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.flag, Some(true));
+    }
+
+    #[test]
+    fn test_option_bool_none() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            flag: Option<bool>,
+        }
+        let row = RowData::from_pairs(vec![("flag", ColumnValue::Null)]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.flag, None);
+    }
+
+    #[test]
+    fn test_option_i32() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            val: Option<i32>,
+        }
+        let row = RowData::from_pairs(vec![("val", ColumnValue::text("-42"))]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.val, Some(-42));
+    }
+
+    // -- Multiple rows deserialization (same struct, different data) ----------
+
+    #[test]
+    fn test_multiple_rows() {
+        let rows = [
+            RowData::from_pairs(vec![
+                ("id", ColumnValue::text("1")),
+                ("username", ColumnValue::text("alice")),
+            ]),
+            RowData::from_pairs(vec![
+                ("id", ColumnValue::text("2")),
+                ("username", ColumnValue::text("bob")),
+            ]),
+            RowData::from_pairs(vec![
+                ("id", ColumnValue::text("3")),
+                ("username", ColumnValue::text("charlie")),
+            ]),
+        ];
+        let users: Vec<UserModel> = rows.iter().map(|r| r.deserialize_into().unwrap()).collect();
+        assert_eq!(users.len(), 3);
+        assert_eq!(users[0].id, 1);
+        assert_eq!(users[1].username, "bob");
+        assert_eq!(users[2].id, 3);
+    }
+
+    // -- Negative floats and special values ----------------------------------
+
+    #[test]
+    fn test_negative_float() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            val: f64,
+        }
+        let row = RowData::from_pairs(vec![("val", ColumnValue::text("-0.001"))]);
+        let v: S = row.deserialize_into().unwrap();
+        assert!((v.val - (-0.001)).abs() < f64::EPSILON);
+    }
+
+    // -- RowData::as_columns test -------------------------------------------
+
+    #[test]
+    fn test_as_columns() {
+        let row = RowData::from_pairs(vec![
+            ("a", ColumnValue::text("1")),
+            ("b", ColumnValue::Null),
+        ]);
+        let cols = row.as_columns();
+        assert_eq!(cols.len(), 2);
+        assert_eq!(cols[0].0.as_ref(), "a");
+        assert_eq!(cols[1].0.as_ref(), "b");
+        assert!(cols[1].1.is_null());
+    }
+
+    // -- RowDataDeserializer::new public constructor -------------------------
+
+    #[test]
+    fn test_row_data_deserializer_direct_use() {
+        use crate::deserializer::RowDataDeserializer;
+        use serde::Deserialize;
+
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("99")),
+            ("username", ColumnValue::text("direct")),
+        ]);
+        let de = RowDataDeserializer::new(&row);
+        let user = UserModel::deserialize(de).unwrap();
+        assert_eq!(user.id, 99);
+        assert_eq!(user.username, "direct");
+    }
+
+    // -- serde(flatten) / HashMap deserialization ----------------------------
+
+    #[test]
+    fn test_deserialize_into_hashmap() {
+        use std::collections::HashMap;
+        let row = RowData::from_pairs(vec![
+            ("name", ColumnValue::text("test")),
+            ("value", ColumnValue::text("42")),
+        ]);
+        // RowData can be deserialized into a HashMap<String, String> via deserialize_any
+        // because visit_str yields string values for Text columns
+        let map: HashMap<String, String> = row.deserialize_into().unwrap();
+        assert_eq!(map.get("name").unwrap(), "test");
+        assert_eq!(map.get("value").unwrap(), "42");
+    }
+
+    // -- deserialize_byte_buf paths -----------------------------------------
+
+    #[test]
+    fn test_byte_buf_from_binary() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            #[serde(with = "serde_bytes")]
+            data: Vec<u8>,
+        }
+        let row = RowData::from_pairs(vec![(
+            "data",
+            ColumnValue::binary_bytes(Bytes::from_static(&[1, 2, 3])),
+        )]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.data, vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn test_byte_buf_null_errors() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[serde(with = "serde_bytes")]
+            #[allow(dead_code)]
+            data: Vec<u8>,
+        }
+        let row = RowData::from_pairs(vec![("data", ColumnValue::Null)]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+    }
+
+    // -- unsupported types at column level ------------------------------------
+
+    #[test]
+    fn test_tuple_not_supported() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            pair: (u32, u32),
+        }
+        let row = RowData::from_pairs(vec![("pair", ColumnValue::text("1,2"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("tuple"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_tuple_struct_not_supported() {
+        #[derive(Debug, Deserialize)]
+        struct Pair(#[allow(dead_code)] u32, #[allow(dead_code)] u32);
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            p: Pair,
+        }
+        let row = RowData::from_pairs(vec![("p", ColumnValue::text("1,2"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("tuple struct"), "got: {msg}");
+    }
+
+    #[test]
+    fn test_nested_map_not_supported() {
+        use std::collections::HashMap;
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            m: HashMap<String, String>,
+        }
+        let row = RowData::from_pairs(vec![("m", ColumnValue::text("{}"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+        let msg = result.unwrap_err().to_string();
+        assert!(msg.contains("nested map"), "got: {msg}");
+    }
+
+    // -- unit_struct from Null -------------------------------------------------
+
+    #[test]
+    fn test_unit_struct_from_null() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Marker;
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            m: Marker,
+        }
+        let row = RowData::from_pairs(vec![("m", ColumnValue::Null)]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.m, Marker);
+    }
+
+    // -- identifier / str paths via flatten ------------------------------------
+
+    #[test]
+    fn test_str_via_hashmap() {
+        use std::collections::HashMap;
+        let row = RowData::from_pairs(vec![("k", ColumnValue::text("v"))]);
+        let map: HashMap<String, String> = row.deserialize_into().unwrap();
+        assert_eq!(map.get("k").unwrap(), "v");
+    }
+
+    // -- deserialize_any on Null produces None (via HashMap<String, Option<String>>) --
+
+    #[test]
+    fn test_any_null_in_hashmap() {
+        use std::collections::HashMap;
+        let row = RowData::from_pairs(vec![
+            ("a", ColumnValue::text("x")),
+            ("b", ColumnValue::Null),
+        ]);
+        let map: HashMap<String, Option<String>> = row.deserialize_into().unwrap();
+        assert_eq!(map.get("a").unwrap(), &Some("x".to_string()));
+        assert_eq!(map.get("b").unwrap(), &None);
+    }
+
+    // -- boolean every accepted form -------------------------------------------
+
+    #[test]
+    fn test_boolean_invalid_single_char() {
+        #[derive(Debug, Deserialize)]
+        struct S {
+            #[allow(dead_code)]
+            a: bool,
+        }
+        let row = RowData::from_pairs(vec![("a", ColumnValue::text("x"))]);
+        let result: crate::error::Result<S> = row.deserialize_into();
+        assert!(result.is_err());
+    }
+
+    // -- i64/u64 boundary ------------------------------------------------------
+
+    #[test]
+    fn test_integer_boundaries() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct S {
+            i: i64,
+            u: u64,
+        }
+        let row = RowData::from_pairs(vec![
+            ("i", ColumnValue::text("-9223372036854775808")),
+            ("u", ColumnValue::text("18446744073709551615")),
+        ]);
+        let v: S = row.deserialize_into().unwrap();
+        assert_eq!(v.i, i64::MIN);
+        assert_eq!(v.u, u64::MAX);
+    }
+
+    // -- RowDataDeserializer::new direct + deserialize_map forwarding ---------
+
+    #[test]
+    fn test_deserializer_deserialize_any() {
+        use crate::deserializer::RowDataDeserializer;
+        use std::collections::HashMap;
+        let row = RowData::from_pairs(vec![("k", ColumnValue::text("v"))]);
+        let de = RowDataDeserializer::new(&row);
+        // HashMap triggers deserialize_map, which goes through deserialize_any fallback path
+        let m: HashMap<String, String> = HashMap::deserialize(de).unwrap();
+        assert_eq!(m.get("k").unwrap(), "v");
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -44,6 +44,9 @@ pub enum ReplicationError {
 
     /// Generic replication errors
     Generic(String),
+
+    /// Deserialization errors (when converting RowData to user types)
+    Deserialize(String),
 }
 
 impl std::fmt::Display for ReplicationError {
@@ -62,6 +65,7 @@ impl std::fmt::Display for ReplicationError {
             Self::Io(err) => write!(f, "IO error: {err}"),
             Self::StringConversion(err) => write!(f, "String conversion error: {err}"),
             Self::Generic(msg) => write!(f, "Replication error: {msg}"),
+            Self::Deserialize(msg) => write!(f, "Deserialization error: {msg}"),
         }
     }
 }
@@ -85,6 +89,12 @@ impl From<std::io::Error> for ReplicationError {
 impl From<std::ffi::NulError> for ReplicationError {
     fn from(err: std::ffi::NulError) -> Self {
         Self::StringConversion(err)
+    }
+}
+
+impl serde::de::Error for ReplicationError {
+    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+        ReplicationError::Deserialize(msg.to_string())
     }
 }
 
@@ -147,6 +157,11 @@ impl ReplicationError {
     /// Create a new generic error
     pub fn generic<S: Into<String>>(msg: S) -> Self {
         ReplicationError::Generic(msg.into())
+    }
+
+    /// Create a new deserialization error
+    pub fn deserialize<S: Into<String>>(msg: S) -> Self {
+        ReplicationError::Deserialize(msg.into())
     }
 
     /// Check if the error is transient (can be retried)
@@ -377,5 +392,48 @@ mod tests {
         // String variants should not have a source
         let err = ReplicationError::protocol("test");
         assert!(err.source().is_none());
+    }
+
+    #[test]
+    fn test_deserialize_error() {
+        let err = ReplicationError::deserialize("field type mismatch");
+        match err {
+            ReplicationError::Deserialize(msg) => assert_eq!(msg, "field type mismatch"),
+            _ => panic!("Expected Deserialize error"),
+        }
+    }
+
+    #[test]
+    fn test_deserialize_error_display() {
+        let err = ReplicationError::deserialize("cannot parse 'abc' as u32");
+        assert_eq!(
+            err.to_string(),
+            "Deserialization error: cannot parse 'abc' as u32"
+        );
+    }
+
+    #[test]
+    fn test_deserialize_error_classification() {
+        let err = ReplicationError::deserialize("test");
+        assert!(!err.is_transient());
+        assert!(!err.is_permanent());
+        assert!(!err.is_cancelled());
+    }
+
+    #[test]
+    fn test_deserialize_error_source() {
+        use std::error::Error;
+        let err = ReplicationError::deserialize("test");
+        assert!(err.source().is_none());
+    }
+
+    #[test]
+    fn test_serde_de_error_custom() {
+        use serde::de::Error;
+        let err = ReplicationError::custom("serde custom error");
+        match err {
+            ReplicationError::Deserialize(msg) => assert_eq!(msg, "serde custom error"),
+            _ => panic!("Expected Deserialize error from serde::de::Error::custom"),
+        }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -125,6 +125,7 @@
 // Core modules
 pub mod buffer;
 pub mod column_value;
+pub mod deserializer;
 pub mod error;
 pub mod types;
 
@@ -145,6 +146,9 @@ pub use lsn::SharedLsnFeedback;
 
 // Re-export column value types
 pub use column_value::{ColumnValue, RowData};
+
+// Re-export deserializer
+pub use deserializer::RowDataDeserializer;
 
 // Re-export type aliases and utilities
 pub use types::{

--- a/src/types.rs
+++ b/src/types.rs
@@ -1120,6 +1120,120 @@ impl ChangeEvent {
         }
     }
 
+    /// Deserialize INSERT data into a user-defined type.
+    ///
+    /// Returns `Ok(value)` for Insert events, or an error for other event types.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use pg_walstream::{ChangeEvent, ColumnValue, Lsn, RowData};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct User { id: u32, name: String }
+    ///
+    /// let data = RowData::from_pairs(vec![
+    ///     ("id", ColumnValue::text("1")),
+    ///     ("name", ColumnValue::text("Alice")),
+    /// ]);
+    /// let event = ChangeEvent::insert("public", "users", 1, data, Lsn::new(100));
+    /// let user: User = event.deserialize_insert().unwrap();
+    /// assert_eq!(user.id, 1);
+    /// ```
+    pub fn deserialize_insert<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
+        match &self.event_type {
+            EventType::Insert { data, .. } => data.deserialize_into(),
+            _ => Err(ReplicationError::deserialize(format!(
+                "expected Insert event, got {}",
+                self.event_type_str()
+            ))),
+        }
+    }
+
+    /// Deserialize both old and new data from an UPDATE event in one call.
+    ///
+    /// Returns `Ok((old, new))` where `old` is `Some(T)` if the replica identity
+    /// provided it (e.g. `REPLICA IDENTITY FULL` or when a key column changed)
+    /// and `None` otherwise. Returns an error for non-Update events.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use pg_walstream::{ChangeEvent, ColumnValue, Lsn, RowData, ReplicaIdentity};
+    /// use serde::Deserialize;
+    /// use std::sync::Arc;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct User { id: u32, name: String }
+    ///
+    /// let old = RowData::from_pairs(vec![
+    ///     ("id", ColumnValue::text("1")),
+    ///     ("name", ColumnValue::text("alice")),
+    /// ]);
+    /// let new = RowData::from_pairs(vec![
+    ///     ("id", ColumnValue::text("1")),
+    ///     ("name", ColumnValue::text("bob")),
+    /// ]);
+    /// let event = ChangeEvent::update(
+    ///     "public", "users", 1, Some(old), new,
+    ///     ReplicaIdentity::Full, vec![Arc::from("id")], Lsn::new(200),
+    /// );
+    /// let (old, new): (Option<User>, User) = event.deserialize_update().unwrap();
+    /// assert_eq!(old.unwrap().name, "alice");
+    /// assert_eq!(new.name, "bob");
+    /// ```
+    pub fn deserialize_update<T: serde::de::DeserializeOwned>(&self) -> Result<(Option<T>, T)> {
+        match &self.event_type {
+            EventType::Update {
+                old_data, new_data, ..
+            } => {
+                let old = match old_data {
+                    Some(data) => Some(data.deserialize_into()?),
+                    None => None,
+                };
+                let new = new_data.deserialize_into()?;
+                Ok((old, new))
+            }
+            _ => Err(ReplicationError::deserialize(format!(
+                "expected Update event, got {}",
+                self.event_type_str()
+            ))),
+        }
+    }
+
+    /// Deserialize DELETE data into a user-defined type.
+    ///
+    /// Returns `Ok(value)` for Delete events, or an error for other event types.
+    pub fn deserialize_delete<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
+        match &self.event_type {
+            EventType::Delete { old_data, .. } => old_data.deserialize_into(),
+            _ => Err(ReplicationError::deserialize(format!(
+                "expected Delete event, got {}",
+                self.event_type_str()
+            ))),
+        }
+    }
+
+    /// Deserialize the primary row data from any DML event.
+    ///
+    /// - Insert: deserializes the inserted data
+    /// - Update: deserializes the new data
+    /// - Delete: deserializes the old (deleted) data
+    ///
+    /// Returns an error for non-DML events (Begin, Commit, Truncate, etc.).
+    pub fn deserialize_data<T: serde::de::DeserializeOwned>(&self) -> Result<T> {
+        match &self.event_type {
+            EventType::Insert { data, .. } => data.deserialize_into(),
+            EventType::Update { new_data, .. } => new_data.deserialize_into(),
+            EventType::Delete { old_data, .. } => old_data.deserialize_into(),
+            _ => Err(ReplicationError::deserialize(format!(
+                "event type '{}' does not contain row data",
+                self.event_type_str()
+            ))),
+        }
+    }
+
     pub fn event_type_str(&self) -> &str {
         match self.event_type {
             EventType::Insert { .. } => "insert",


### PR DESCRIPTION
Introduces automatic deserialization of WAL rows into user-defined Rust types via serde.

- New `src/deserializer.rs` module providing `RowDataDeserializer` with text-to-type coercion (numerics, bool, char, String, bytes, Option, unit, newtype, enum unit variants).
- `RowData::deserialize_into<T>()` — deserialize a row into T.
- `ChangeEvent` convenience methods:
- `deserialize_insert<T>()`
- `deserialize_update<T>() -> (Option<T>, T)` — old + new in one shot
- `deserialize_delete<T>()`
- `deserialize_data<T>()` — primary row from any DML event
- `ReplicationError::Deserialize` variant + `serde::de::Error` impl.
- `examples/typed-deserialization/` — end-to-end usage example.
- Comprehensive unit tests covering numerics, options, enums, newtypes, serde attributes, unsupported-type errors, NULL/Binary  error paths, and all ChangeEvent convenience methods.