### PR TITLE
Make tokio and the connection layer optional for parser-only builds

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,8 +13,8 @@ keywords = ["postgresql", "replication", "wal", "logical-decoding", "streaming"]
 categories = ["database", "parsing", "network-programming"]
 
 [dependencies]
-tokio = { version = "1.52.3", features = ["io-util", "net", "time", "macros", "rt", "rt-multi-thread"] }
-tokio-util = "0.7.18"
+tokio = { version = "1.52.3", features = ["io-util", "net", "time", "macros", "rt", "rt-multi-thread"], optional = true }
+tokio-util = { version = "0.7.18", optional = true }
 serde = { version = "1.0.228", features = ["derive", "rc"] }
 chrono = { version = "0.4.45", features = ["serde"] }
 bytes = { version = "1.11.1", features = ["serde"] }
@@ -36,10 +36,12 @@ socket2 = { version = "0.6.4", features = ["all"], optional = true }
 
 [features]
 default = ["libpq"]
-libpq = ["dep:libpq-sys"]
+libpq = ["dep:libpq-sys", "dep:tokio", "dep:tokio-util"]
 
 # Pure-Rust native backend: uses rustls with aws-lc-rs forhardware-accelerated TLS crypto (AES-NI, AVX2, SHA-NI), requires cmake + C compiler at build time.
 rustls-tls = [
+    "dep:tokio",
+    "dep:tokio-util",
     "dep:tokio-rustls",
     "dep:rustls",
     "dep:webpki-roots",

--- a/integration-tests/complex_types.rs
+++ b/integration-tests/complex_types.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
 //! Integration tests for complex PostgreSQL data types through logical replication.
 //!
 //! These tests verify that the library correctly streams and represents complex

--- a/integration-tests/rate_limited_streaming.rs
+++ b/integration-tests/rate_limited_streaming.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
 //! Integration tests for the rate-limited streaming pattern.
 //!
 //! These tests verify that the `into_stream()` / `EventStream` API works

--- a/integration-tests/safe_transaction_consumer.rs
+++ b/integration-tests/safe_transaction_consumer.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
 //! Integration tests for the safe transaction consumer pattern.
 //!
 //! These tests verify the transaction-buffered consumption pattern

--- a/integration-tests/snapshot_export.rs
+++ b/integration-tests/snapshot_export.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
 //! Integration tests for the EXPORT_SNAPSHOT workflow.
 //!
 //! These tests verify the PostgreSQL snapshot lifecycle when using

--- a/integration-tests/ssl_connections.rs
+++ b/integration-tests/ssl_connections.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
 //! Integration tests for SSL/TLS connection modes.
 //!
 //! These tests verify that the rustls-tls backend correctly handles different

--- a/integration-tests/typed_deserialization.rs
+++ b/integration-tests/typed_deserialization.rs
@@ -1,3 +1,5 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
 //! Integration tests for the typed deserialization API end-to-end through
 //! pgoutput logical replication.
 //!

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -16,12 +16,6 @@
 //! Both backends expose the same public types: `PgReplicationConnection` and
 //! `PgResult`.
 
-#[cfg(not(any(feature = "libpq", feature = "rustls-tls")))]
-compile_error!(
-    "Either the `libpq` or `rustls-tls` feature must be enabled. \
-     Example: --features libpq"
-);
-
 // ── libpq backend (default) ──────────────────────────────────────────────────
 
 #[cfg(all(feature = "libpq", not(feature = "rustls-tls")))]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,9 +135,12 @@ pub mod lsn;
 pub mod protocol;
 
 // High-level stream management
+#[cfg(any(feature = "libpq", feature = "rustls-tls"))]
 pub mod stream;
 
+#[cfg(any(feature = "libpq", feature = "rustls-tls"))]
 pub mod connection;
+#[cfg(any(feature = "libpq", feature = "rustls-tls"))]
 pub mod retry;
 
 // Re-export main types for convenience
@@ -186,18 +189,22 @@ pub use protocol::{
 };
 
 // Re-export stream types
+#[cfg(any(feature = "libpq", feature = "rustls-tls"))]
 pub use stream::{
     EventStream, EventStreamRef, LogicalReplicationStream, OriginFilter, ReplicationStreamConfig,
     StreamingMode,
 };
 
 // Re-export tokio_util for CancellationToken
+#[cfg(any(feature = "libpq", feature = "rustls-tls"))]
 pub use tokio_util::sync::CancellationToken;
 
 // Re-export libpq-specific types
+#[cfg(any(feature = "libpq", feature = "rustls-tls"))]
 pub use connection::{PgReplicationConnection, PgResult};
 
 // Re-export retry types
+#[cfg(any(feature = "libpq", feature = "rustls-tls"))]
 pub use retry::{ExponentialBackoff, ReplicationConnectionRetry, RetryConfig};
 
 // Re-export SQL builder utilities


### PR DESCRIPTION
`tokio` and `tokio-util` were hard dependencies even though only the connection backends use them, so a consumer who wanted just the protocol parser still pulled the async runtime. This makes both optional, has `libpq` and `rustls-tls` pull them, and gates `stream`, `connection`, and `retry` behind those features. Defaults are unchanged, while `default-features = false` now produces a parser-only build with no `tokio` and no connection backend in the tree (confirmed with `cargo tree`).

A backend used to be mandatory (a `compile_error!` rejected building with neither feature). That guard is removed, since the backendless parser-only build is now a supported configuration, and the connection integration tests are gated to the backend features so it still compiles.

Closes #69, and lays the groundwork for the `no_std` parser in #70.
