### PR TITLE
Support `no_std` and `alloc` builds for the protocol parser

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,29 @@ jobs:
     - name: Run unit tests
       run: cargo test --lib --verbose
 
+  no_std:
+    name: no_std builds (host, wasm, bare-metal)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        targets: wasm32-unknown-unknown, aarch64-unknown-none
+
+    - name: Build no_std (alloc) on the host
+      run: cargo build --no-default-features
+
+    - name: Build no_std (alloc) for wasm32-unknown-unknown
+      run: cargo build --no-default-features --target wasm32-unknown-unknown
+
+    - name: Build no_std (alloc) for aarch64-unknown-none (bare-metal)
+      run: cargo build --no-default-features --lib --target aarch64-unknown-none
+
+    - name: Clippy no_std (alloc)
+      run: cargo clippy --no-default-features --lib -- -D warnings
+
   security:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -212,10 +212,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -937,6 +935,7 @@ dependencies = [
  "rustls",
  "serde",
  "serde_bytes",
+ "serde_json",
  "smallvec",
  "socket2",
  "tokio",
@@ -1552,19 +1551,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,17 +10,17 @@ documentation = "https://docs.rs/pg_walstream"
 readme = "README.md"
 description = "PostgreSQL logical replication protocol library - parse and handle PostgreSQL WAL streaming messages"
 keywords = ["postgresql", "replication", "wal", "logical-decoding", "streaming"]
-categories = ["database", "parsing", "network-programming"]
+categories = ["database", "parsing", "network-programming", "no-std"]
 
 [dependencies]
 tokio = { version = "1.52.3", features = ["io-util", "net", "time", "macros", "rt", "rt-multi-thread"], optional = true }
 tokio-util = { version = "0.7.18", optional = true }
-serde = { version = "1.0.228", features = ["derive", "rc"] }
-chrono = { version = "0.4.45", features = ["serde"] }
-bytes = { version = "1.11.1", features = ["serde"] }
-tracing = "0.1.44"
-futures-core = "0.3.32"
-memchr = "2.8.2"
+serde = { version = "1.0.228", default-features = false, features = ["derive", "rc", "alloc"] }
+chrono = { version = "0.4.45", default-features = false, features = ["serde", "alloc"] }
+bytes = { version = "1.11.1", default-features = false, features = ["serde"] }
+tracing = { version = "0.1.44", default-features = false }
+futures-core = { version = "0.3.32", default-features = false }
+memchr = { version = "2.8.2", default-features = false }
 smallvec = { version = "1.15.2", features = ["serde"] }
 
 # libpq backend (default)
@@ -35,8 +35,21 @@ aws-lc-rs = { version = "1.17.0", optional = true }
 socket2 = { version = "0.6.4", features = ["all"], optional = true }
 
 [features]
-default = ["libpq"]
-libpq = ["dep:libpq-sys", "dep:tokio", "dep:tokio-util"]
+default = ["std", "libpq"]
+
+# Standard library support, on by default. Disable with `--no-default-features`
+# for a no_std + alloc parser-only build (targets wasm and embedded).
+std = [
+    "serde/std",
+    "chrono/std",
+    "chrono/clock",
+    "bytes/std",
+    "tracing/std",
+    "futures-core/std",
+    "memchr/std",
+]
+
+libpq = ["dep:libpq-sys", "dep:tokio", "dep:tokio-util", "std"]
 
 # Pure-Rust native backend: uses rustls with aws-lc-rs forhardware-accelerated TLS crypto (AES-NI, AVX2, SHA-NI), requires cmake + C compiler at build time.
 rustls-tls = [
@@ -49,6 +62,7 @@ rustls-tls = [
     "dep:aws-lc-rs",
     "dep:socket2",
     "rustls/aws_lc_rs",
+    "std",
 ]
 
 [dev-dependencies]
@@ -57,6 +71,7 @@ criterion = { version = "0.8.2", features = ["html_reports"] }
 futures = "0.3.32"
 serde_bytes = "0.11.19"
 proptest = "1"
+serde_json = "1"
 
 [[test]]
 name = "snapshot_export"

--- a/README.md
+++ b/README.md
@@ -54,14 +54,15 @@ pg_walstream = { version = "0.6.3", default-features = false, features = ["rustl
 
 ## Feature Flags
 
-pg-walstream provides two connection backends, selected at compile time. When both are enabled, `rustls-tls` takes priority:
+pg-walstream provides two connection backends plus a `std` toggle, all selected at compile time. When both backends are enabled, `rustls-tls` takes priority:
 
 | Feature | Default | C Dependencies | Description |
 |---------|---------|----------------|-------------|
-| `libpq` | Yes | `libpq-dev`, `libclang-dev` | Uses PostgreSQL's C client library via FFI. Battle-tested, supports all auth methods natively. |
-| `rustls-tls` | No | `cmake`, `gcc` (build-time only) | Pure-Rust implementation using `rustls` with `aws-lc-rs` crypto backend for hardware-accelerated TLS. No runtime C dependencies. Takes priority when both features are enabled. |
+| `std` | Yes | None | Standard library support. Disable with `default-features = false` for a `no_std` plus `alloc` parser-only build (no connection layer) that compiles for `wasm32-unknown-unknown` and embedded targets. |
+| `libpq` | Yes | `libpq-dev`, `libclang-dev` | Uses PostgreSQL's C client library via FFI. Battle-tested, supports all auth methods natively. Implies `std`. |
+| `rustls-tls` | No | `cmake`, `gcc` (build-time only) | Pure-Rust implementation using `rustls` with `aws-lc-rs` crypto backend for hardware-accelerated TLS. No runtime C dependencies. Takes priority when both backends are enabled. Implies `std`. |
 
-> **Note:** At least one feature must be enabled. Building with no backend features will produce a compile error.
+> **Note:** The protocol parser, encoder, and types need no backend. Building with `default-features = false` gives a `no_std` plus `alloc` build of just those, suitable for wasm and embedded. A connection backend (`libpq` or `rustls-tls`) is required only for the live streaming and connection APIs, and pulls in `std`.
 
 ## System Dependencies
 

--- a/src/buffer.rs
+++ b/src/buffer.rs
@@ -4,6 +4,7 @@
 //! in PostgreSQL's logical replication protocol format using the bytes crate.
 
 use crate::error::{ReplicationError, Result};
+use crate::prelude::*;
 use bytes::{Buf, BufMut, Bytes, BytesMut};
 
 /// Buffer reader for parsing binary protocol messages
@@ -151,7 +152,7 @@ impl BufferReader {
         })?;
 
         // Validate UTF-8 on the borrowed slice (zero-copy), then create one owned String
-        let result = std::str::from_utf8(&data_slice[..bytes_to_read])
+        let result = core::str::from_utf8(&data_slice[..bytes_to_read])
             .map_err(|e| ReplicationError::protocol(format!("Invalid UTF-8 in string: {e}")))?
             .to_owned();
 
@@ -163,17 +164,17 @@ impl BufferReader {
 
     /// Read a null-terminated string directly into `Arc<str>` (avoids intermediate String allocation).
     #[inline]
-    pub fn read_cstring_arc(&mut self) -> Result<std::sync::Arc<str>> {
+    pub fn read_cstring_arc(&mut self) -> Result<Arc<str>> {
         let data_slice = self.data.chunk();
 
         let bytes_to_read = memchr::memchr(0, data_slice).ok_or_else(|| {
             ReplicationError::protocol("Unterminated string in buffer".to_string())
         })?;
 
-        let result = std::str::from_utf8(&data_slice[..bytes_to_read])
+        let result = core::str::from_utf8(&data_slice[..bytes_to_read])
             .map_err(|e| ReplicationError::protocol(format!("Invalid UTF-8 in string: {e}")))?;
 
-        let arc: std::sync::Arc<str> = std::sync::Arc::from(result);
+        let arc: Arc<str> = Arc::from(result);
 
         self.data.advance(bytes_to_read + 1);
 
@@ -184,7 +185,7 @@ impl BufferReader {
     #[inline]
     pub fn read_string(&mut self, length: usize) -> Result<String> {
         self.ensure_bytes(length)?;
-        let result = std::str::from_utf8(&self.data.chunk()[..length])
+        let result = core::str::from_utf8(&self.data.chunk()[..length])
             .map_err(|e| ReplicationError::protocol(format!("Invalid UTF-8 in string: {e}")))?
             .to_owned();
         self.data.advance(length);

--- a/src/column_value.rs
+++ b/src/column_value.rs
@@ -7,11 +7,11 @@
 
 use crate::buffer::BufferReader;
 use crate::error::{ReplicationError, Result};
+use crate::prelude::*;
 use bytes::{Bytes, BytesMut};
 use serde::ser::SerializeMap;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-use std::sync::Arc;
 
 /// Encode a byte slice as lowercase hex string.
 pub(crate) fn hex_encode(bytes: &[u8]) -> String {
@@ -25,7 +25,7 @@ pub(crate) fn hex_encode(bytes: &[u8]) -> String {
 }
 
 /// Decode a hex string to bytes. Returns `Err` on invalid hex.
-fn hex_decode(hex: &str) -> std::result::Result<Vec<u8>, &'static str> {
+fn hex_decode(hex: &str) -> core::result::Result<Vec<u8>, &'static str> {
     if !hex.len().is_multiple_of(2) {
         return Err("odd hex length");
     }
@@ -128,7 +128,7 @@ impl ColumnValue {
     #[inline]
     pub fn as_str(&self) -> Option<&str> {
         match self {
-            Self::Text(b) => std::str::from_utf8(b).ok(),
+            Self::Text(b) => core::str::from_utf8(b).ok(),
             _ => None,
         }
     }
@@ -189,11 +189,11 @@ impl ColumnValue {
     }
 }
 
-impl std::fmt::Display for ColumnValue {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ColumnValue {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Null => write!(f, "NULL"),
-            Self::Text(b) => match std::str::from_utf8(b) {
+            Self::Text(b) => match core::str::from_utf8(b) {
                 Ok(s) => write!(f, "{s}"),
                 Err(_) => write!(f, "<invalid utf-8: {} bytes>", b.len()),
             },
@@ -242,10 +242,10 @@ impl Serialize for ColumnValue {
     fn serialize<S: serde::Serializer>(
         &self,
         serializer: S,
-    ) -> std::result::Result<S::Ok, S::Error> {
+    ) -> core::result::Result<S::Ok, S::Error> {
         match self {
             Self::Null => serializer.serialize_none(),
-            Self::Text(b) => match std::str::from_utf8(b) {
+            Self::Text(b) => match core::str::from_utf8(b) {
                 Ok(s) => serializer.serialize_str(s),
                 Err(_) => {
                     // Non-UTF-8 text cannot be represented as a JSON string, Emit the tagged binary form so the bytes survive round-trip.
@@ -266,42 +266,42 @@ impl Serialize for ColumnValue {
 impl<'de> Deserialize<'de> for ColumnValue {
     fn deserialize<D: serde::Deserializer<'de>>(
         deserializer: D,
-    ) -> std::result::Result<Self, D::Error> {
+    ) -> core::result::Result<Self, D::Error> {
         struct Visitor;
 
         impl<'de> serde::de::Visitor<'de> for Visitor {
             type Value = ColumnValue;
 
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 f.write_str(r#"a string, null, or {"$binary": "hex..."}"#)
             }
 
-            fn visit_none<E: serde::de::Error>(self) -> std::result::Result<ColumnValue, E> {
+            fn visit_none<E: serde::de::Error>(self) -> core::result::Result<ColumnValue, E> {
                 Ok(ColumnValue::Null)
             }
 
-            fn visit_unit<E: serde::de::Error>(self) -> std::result::Result<ColumnValue, E> {
+            fn visit_unit<E: serde::de::Error>(self) -> core::result::Result<ColumnValue, E> {
                 Ok(ColumnValue::Null)
             }
 
             fn visit_some<D: serde::Deserializer<'de>>(
                 self,
                 deserializer: D,
-            ) -> std::result::Result<ColumnValue, D::Error> {
+            ) -> core::result::Result<ColumnValue, D::Error> {
                 deserializer.deserialize_any(self)
             }
 
             fn visit_str<E: serde::de::Error>(
                 self,
                 v: &str,
-            ) -> std::result::Result<ColumnValue, E> {
+            ) -> core::result::Result<ColumnValue, E> {
                 Ok(ColumnValue::Text(Bytes::copy_from_slice(v.as_bytes())))
             }
 
             fn visit_map<M: serde::de::MapAccess<'de>>(
                 self,
                 mut map: M,
-            ) -> std::result::Result<ColumnValue, M::Error> {
+            ) -> core::result::Result<ColumnValue, M::Error> {
                 use serde::de::Error;
                 let key: String = map
                     .next_key()?
@@ -522,7 +522,7 @@ impl RowData {
         for _ in 0..count {
             let name_len = reader.read_u16()? as usize;
             let name_bytes = reader.read_bytes(name_len)?;
-            let name = std::str::from_utf8(&name_bytes)
+            let name = core::str::from_utf8(&name_bytes)
                 .map_err(|e| ReplicationError::protocol(format!("Invalid column name: {e}")))?;
             let name = Arc::from(name);
             let value = ColumnValue::decode(reader)?;
@@ -549,7 +549,7 @@ impl Serialize for RowData {
     fn serialize<S: serde::Serializer>(
         &self,
         serializer: S,
-    ) -> std::result::Result<S::Ok, S::Error> {
+    ) -> core::result::Result<S::Ok, S::Error> {
         use serde::ser::SerializeMap;
         let mut map = serializer.serialize_map(Some(self.columns.len()))?;
         for (k, v) in &self.columns {
@@ -562,20 +562,20 @@ impl Serialize for RowData {
 impl<'de> Deserialize<'de> for RowData {
     fn deserialize<D: serde::Deserializer<'de>>(
         deserializer: D,
-    ) -> std::result::Result<Self, D::Error> {
+    ) -> core::result::Result<Self, D::Error> {
         struct Visitor;
 
         impl<'de> serde::de::Visitor<'de> for Visitor {
             type Value = RowData;
 
-            fn expecting(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+            fn expecting(&self, f: &mut core::fmt::Formatter) -> core::fmt::Result {
                 f.write_str("a map of column names to values")
             }
 
             fn visit_map<M: serde::de::MapAccess<'de>>(
                 self,
                 mut map: M,
-            ) -> std::result::Result<RowData, M::Error> {
+            ) -> core::result::Result<RowData, M::Error> {
                 let mut cols = SmallVec::with_capacity(map.size_hint().unwrap_or(0));
                 while let Some((k, v)) = map.next_entry::<String, ColumnValue>()? {
                     cols.push((Arc::from(k), v));
@@ -1031,5 +1031,57 @@ mod tests {
 
         assert_eq!(row, decoded);
         assert_eq!(decoded.len(), 12);
+    }
+
+    #[test]
+    fn serde_json_round_trips_null_text_binary() {
+        for cv in [
+            ColumnValue::Null,
+            ColumnValue::text("hello"),
+            ColumnValue::Binary(Bytes::from_static(&[0u8, 1, 2, 255])),
+        ] {
+            let json = serde_json::to_string(&cv).unwrap();
+            let back: ColumnValue = serde_json::from_str(&json).unwrap();
+            assert_eq!(cv, back, "round trip failed via {json}");
+        }
+    }
+
+    #[test]
+    fn serde_text_invalid_utf8_round_trips_as_binary() {
+        let cv = ColumnValue::Text(Bytes::from_static(&[0xff, 0xfe]));
+        let json = serde_json::to_string(&cv).unwrap();
+        assert!(json.contains("$binary"));
+        let back: ColumnValue = serde_json::from_str(&json).unwrap();
+        assert_eq!(back, ColumnValue::Binary(Bytes::from_static(&[0xff, 0xfe])));
+    }
+
+    #[test]
+    fn serde_column_value_rejects_bad_input() {
+        assert!(serde_json::from_str::<ColumnValue>(r#"{"nope":"x"}"#).is_err());
+        assert!(serde_json::from_str::<ColumnValue>(r#"{"$binary":"zz"}"#).is_err());
+        assert!(serde_json::from_str::<ColumnValue>("42").is_err());
+    }
+
+    #[test]
+    fn serde_visit_unit_is_null() {
+        use serde::de::value::{Error as ValueError, UnitDeserializer};
+        let cv = ColumnValue::deserialize(UnitDeserializer::<ValueError>::new()).unwrap();
+        assert_eq!(cv, ColumnValue::Null);
+    }
+
+    #[test]
+    fn rowdata_serde_json_round_trip() {
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("1")),
+            ("name", ColumnValue::text("alice")),
+            (
+                "blob",
+                ColumnValue::Binary(Bytes::from_static(&[1u8, 2, 3])),
+            ),
+        ]);
+        let json = serde_json::to_string(&row).unwrap();
+        let back: RowData = serde_json::from_str(&json).unwrap();
+        assert_eq!(row, back);
+        assert!(serde_json::from_str::<RowData>("42").is_err());
     }
 }

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -28,8 +28,8 @@
 
 use crate::column_value::{ColumnValue, RowData};
 use crate::error::ReplicationError;
+use crate::prelude::*;
 use serde::de::{self, DeserializeSeed, MapAccess, Visitor};
-use std::sync::Arc;
 
 /// Parse PostgreSQL's boolean text vocabulary.
 ///
@@ -127,7 +127,7 @@ where
 
 /// Render a byte slice as a string for error messages, lossy on non-UTF-8.
 #[inline]
-fn lossy_token(b: &[u8]) -> std::borrow::Cow<'_, str> {
+fn lossy_token(b: &[u8]) -> Cow<'_, str> {
     String::from_utf8_lossy(b)
 }
 
@@ -189,7 +189,7 @@ impl<'de, 'a> de::Deserializer<'de> for RowDataDeserializer<'a> {
 // ---------------------------------------------------------------------------
 
 struct RowDataMapAccess<'a> {
-    iter: std::slice::Iter<'a, (Arc<str>, ColumnValue)>,
+    iter: core::slice::Iter<'a, (Arc<str>, ColumnValue)>,
     current_value: Option<&'a ColumnValue>,
 }
 
@@ -243,7 +243,7 @@ impl<'a> ColumnValueDeserializer<'a> {
     #[inline]
     fn text_or_err(&self, target: &str) -> Result<&'a str, ReplicationError> {
         match self.value {
-            ColumnValue::Text(b) => std::str::from_utf8(b).map_err(|e| {
+            ColumnValue::Text(b) => core::str::from_utf8(b).map_err(|e| {
                 ReplicationError::deserialize(format!("invalid UTF-8 for {target}: {e}"))
             }),
             ColumnValue::Null => Err(ReplicationError::deserialize(format!(
@@ -273,9 +273,9 @@ impl<'a> ColumnValueDeserializer<'a> {
 
     /// Parse text as a numeric type via the std `FromStr` (used for floats).
     #[inline]
-    fn parse_text<T: std::str::FromStr>(&self, type_name: &str) -> Result<T, ReplicationError>
+    fn parse_text<T: core::str::FromStr>(&self, type_name: &str) -> Result<T, ReplicationError>
     where
-        T::Err: std::fmt::Display,
+        T::Err: core::fmt::Display,
     {
         let s = self.text_or_err(type_name)?;
         s.parse::<T>().map_err(|e| {
@@ -313,7 +313,7 @@ impl<'a> ColumnValueDeserializer<'a> {
 #[cold]
 #[inline(never)]
 fn numeric_parse_error(b: &[u8], type_name: &str) -> ReplicationError {
-    match std::str::from_utf8(b) {
+    match core::str::from_utf8(b) {
         Ok(s) => ReplicationError::deserialize(format!("failed to parse '{s}' as {type_name}")),
         Err(e) => ReplicationError::deserialize(format!("invalid UTF-8 for {type_name}: {e}")),
     }
@@ -326,7 +326,7 @@ impl<'de, 'a> de::Deserializer<'de> for ColumnValueDeserializer<'a> {
     fn deserialize_any<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         match self.value {
             ColumnValue::Null => visitor.visit_none(),
-            ColumnValue::Text(b) => match std::str::from_utf8(b) {
+            ColumnValue::Text(b) => match core::str::from_utf8(b) {
                 Ok(s) => visitor.visit_str(s),
                 Err(_) => visitor.visit_bytes(b),
             },
@@ -560,8 +560,8 @@ pub struct FieldError {
     pub message: String,
 }
 
-impl std::fmt::Display for FieldError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for FieldError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "field '{}': {}", self.field, self.message)
     }
 }
@@ -588,7 +588,7 @@ impl<T> TryDeserializeResult<T> {
     }
 
     /// Convert into a standard `Result`: `Ok(value)` if no errors, else `Err(errors)`.
-    pub fn into_result(self) -> std::result::Result<T, Vec<FieldError>> {
+    pub fn into_result(self) -> core::result::Result<T, Vec<FieldError>> {
         if self.errors.is_empty() {
             Ok(self.value)
         } else {
@@ -599,13 +599,13 @@ impl<T> TryDeserializeResult<T> {
 
 /// Shared lenient context passed down through the deserializer chain.
 pub(crate) struct LenientCtx {
-    errors: std::cell::RefCell<Vec<FieldError>>,
+    errors: core::cell::RefCell<Vec<FieldError>>,
 }
 
 impl LenientCtx {
     fn new() -> Self {
         Self {
-            errors: std::cell::RefCell::new(Vec::new()),
+            errors: core::cell::RefCell::new(Vec::new()),
         }
     }
 
@@ -668,7 +668,7 @@ impl<'de, 'a> de::Deserializer<'de> for LenientRowDataDeserializer<'a> {
 }
 
 struct LenientMapAccess<'a> {
-    iter: std::slice::Iter<'a, (Arc<str>, ColumnValue)>,
+    iter: core::slice::Iter<'a, (Arc<str>, ColumnValue)>,
     current: Option<(&'a str, &'a ColumnValue)>,
     ctx: &'a LenientCtx,
 }
@@ -721,7 +721,7 @@ impl<'a> LenientColumnValueDeserializer<'a> {
     /// Get the text content, recording a field error and returning `None` on failure.
     fn try_text(&self, target: &str) -> Option<&'a str> {
         match self.value {
-            ColumnValue::Text(b) => match std::str::from_utf8(b) {
+            ColumnValue::Text(b) => match core::str::from_utf8(b) {
                 Ok(s) => Some(s),
                 Err(e) => {
                     self.ctx
@@ -749,8 +749,8 @@ impl<'a> LenientColumnValueDeserializer<'a> {
     /// Parse text into `T`; record an error and return the type's default on failure.
     fn parse_or_default<T>(&self, target: &str) -> T
     where
-        T: std::str::FromStr + Default,
-        T::Err: std::fmt::Display,
+        T: core::str::FromStr + Default,
+        T::Err: core::fmt::Display,
     {
         match self.try_text(target) {
             Some(s) => s.parse::<T>().unwrap_or_else(|e| {
@@ -772,7 +772,7 @@ impl<'de, 'a> de::Deserializer<'de> for LenientColumnValueDeserializer<'a> {
         // Mirror strict deserialize_any; these paths don't error.
         match self.value {
             ColumnValue::Null => visitor.visit_none(),
-            ColumnValue::Text(b) => match std::str::from_utf8(b) {
+            ColumnValue::Text(b) => match core::str::from_utf8(b) {
                 Ok(s) => visitor.visit_str(s),
                 Err(_) => visitor.visit_bytes(b),
             },
@@ -958,7 +958,7 @@ impl<'de, 'a> de::Deserializer<'de> for LenientColumnValueDeserializer<'a> {
     ) -> Result<V::Value, Self::Error> {
         // Enum has no sensible per-field default; propagate strict behavior.
         let s = match self.value {
-            ColumnValue::Text(b) => std::str::from_utf8(b).map_err(|e| {
+            ColumnValue::Text(b) => core::str::from_utf8(b).map_err(|e| {
                 ReplicationError::deserialize(format!("invalid UTF-8 for enum: {e}"))
             })?,
             ColumnValue::Null => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,6 +3,8 @@
 //! This module provides error types specifically for replication protocol
 //! operations, connection handling, and message parsing.
 
+use crate::prelude::*;
+
 /// Comprehensive error types for replication operations
 #[derive(Debug)]
 pub enum ReplicationError {
@@ -36,9 +38,11 @@ pub enum ReplicationError {
     /// Configuration errors
     Config(String),
 
+    #[cfg(feature = "std")]
     /// IO errors
     Io(std::io::Error),
 
+    #[cfg(feature = "std")]
     /// String conversion errors (from CString operations)
     StringConversion(std::ffi::NulError),
 
@@ -49,8 +53,8 @@ pub enum ReplicationError {
     Deserialize(String),
 }
 
-impl std::fmt::Display for ReplicationError {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for ReplicationError {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             Self::Protocol(msg) => write!(f, "Protocol parsing error: {msg}"),
             Self::Buffer(msg) => write!(f, "Buffer error: {msg}"),
@@ -62,7 +66,9 @@ impl std::fmt::Display for ReplicationError {
             Self::Timeout(msg) => write!(f, "Operation timed out: {msg}"),
             Self::Cancelled(msg) => write!(f, "Operation was cancelled: {msg}"),
             Self::Config(msg) => write!(f, "Configuration error: {msg}"),
+            #[cfg(feature = "std")]
             Self::Io(err) => write!(f, "IO error: {err}"),
+            #[cfg(feature = "std")]
             Self::StringConversion(err) => write!(f, "String conversion error: {err}"),
             Self::Generic(msg) => write!(f, "Replication error: {msg}"),
             Self::Deserialize(msg) => write!(f, "Deserialization error: {msg}"),
@@ -70,22 +76,26 @@ impl std::fmt::Display for ReplicationError {
     }
 }
 
-impl std::error::Error for ReplicationError {
-    fn source(&self) -> Option<&(dyn std::error::Error + 'static)> {
+impl core::error::Error for ReplicationError {
+    fn source(&self) -> Option<&(dyn core::error::Error + 'static)> {
         match self {
+            #[cfg(feature = "std")]
             Self::Io(err) => Some(err),
+            #[cfg(feature = "std")]
             Self::StringConversion(err) => Some(err),
             _ => None,
         }
     }
 }
 
+#[cfg(feature = "std")]
 impl From<std::io::Error> for ReplicationError {
     fn from(err: std::io::Error) -> Self {
         Self::Io(err)
     }
 }
 
+#[cfg(feature = "std")]
 impl From<std::ffi::NulError> for ReplicationError {
     fn from(err: std::ffi::NulError) -> Self {
         Self::StringConversion(err)
@@ -93,7 +103,7 @@ impl From<std::ffi::NulError> for ReplicationError {
 }
 
 impl serde::de::Error for ReplicationError {
-    fn custom<T: std::fmt::Display>(msg: T) -> Self {
+    fn custom<T: core::fmt::Display>(msg: T) -> Self {
         ReplicationError::Deserialize(msg.to_string())
     }
 }
@@ -166,11 +176,14 @@ impl ReplicationError {
 
     /// Check if the error is transient (can be retried)
     pub fn is_transient(&self) -> bool {
+        #[cfg(feature = "std")]
+        if matches!(self, ReplicationError::Io(_)) {
+            return true;
+        }
         matches!(
             self,
             ReplicationError::TransientConnection(_)
                 | ReplicationError::Timeout(_)
-                | ReplicationError::Io(_)
                 | ReplicationError::ReplicationConnection(_)
         )
     }
@@ -192,7 +205,7 @@ impl ReplicationError {
 }
 
 /// Result type for replication operations
-pub type Result<T> = std::result::Result<T, ReplicationError>;
+pub type Result<T> = core::result::Result<T, ReplicationError>;
 
 #[cfg(test)]
 mod tests {
@@ -223,6 +236,29 @@ mod tests {
         assert!(err.is_transient());
         assert!(!err.is_permanent());
         assert!(!err.is_cancelled());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_io_error_is_transient() {
+        let err = ReplicationError::Io(std::io::Error::other("disk hiccup"));
+        assert!(err.is_transient());
+        assert!(!err.is_permanent());
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_io_error_display() {
+        let err = ReplicationError::Io(std::io::Error::other("boom"));
+        assert_eq!(err.to_string(), "IO error: boom");
+    }
+
+    #[cfg(feature = "std")]
+    #[test]
+    fn test_string_conversion_error_display() {
+        let nul = std::ffi::CString::new("a\0b").unwrap_err();
+        let err = ReplicationError::StringConversion(nul);
+        assert!(err.to_string().starts_with("String conversion error:"));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,6 +121,24 @@
 //!     Ok(())
 //! }
 //! ```
+#![cfg_attr(not(feature = "std"), no_std)]
+
+extern crate alloc;
+
+/// Common `alloc` re-exports so each module can `use crate::prelude::*` and work
+/// in both `std` and `no_std + alloc` builds. Glob-imported, so unused entries
+/// never warn, and under `std` they shadow the identical prelude items harmlessly.
+#[allow(unused_imports)]
+pub(crate) mod prelude {
+    pub(crate) use alloc::borrow::{Cow, ToOwned};
+    pub(crate) use alloc::boxed::Box;
+    pub(crate) use alloc::collections::BTreeMap;
+    pub(crate) use alloc::format;
+    pub(crate) use alloc::string::{String, ToString};
+    pub(crate) use alloc::sync::Arc;
+    pub(crate) use alloc::vec;
+    pub(crate) use alloc::vec::Vec;
+}
 
 // Core modules
 pub mod buffer;
@@ -161,7 +179,6 @@ pub use types::{
     format_lsn,
     parse_lsn,
     postgres_timestamp_to_chrono,
-    system_time_to_postgres_timestamp,
     // High-level CDC types
     BaseBackupOptions,
     ChangeEvent,
@@ -181,6 +198,10 @@ pub use types::{
     INVALID_XLOG_REC_PTR,
     PG_EPOCH_OFFSET_SECS,
 };
+
+// `system_time_to_postgres_timestamp` needs a `SystemTime`, so it is std-only.
+#[cfg(feature = "std")]
+pub use types::system_time_to_postgres_timestamp;
 
 // Re-export protocol types
 pub use protocol::{

--- a/src/lsn.rs
+++ b/src/lsn.rs
@@ -12,9 +12,9 @@
 //! we need a thread-safe way to share the committed LSN from consumer back to producer
 //! for accurate feedback to PostgreSQL.
 
+use crate::prelude::*;
 use crate::types::{format_lsn, CachePadded, XLogRecPtr};
-use std::sync::atomic::{AtomicU64, Ordering};
-use std::sync::Arc;
+use core::sync::atomic::{AtomicU64, Ordering};
 use tracing::{debug, info};
 
 /// Thread-safe tracker for LSN positions used in replication feedback

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -5,58 +5,24 @@
 //! - <https://www.postgresql.org/docs/current/protocol-logicalrep-message-formats.html>
 //! - <https://www.postgresql.org/docs/current/protocol-logical-replication.html>
 
-use crate::buffer::{BufferReader, BufferWriter};
+use crate::buffer::BufferReader;
+#[cfg(feature = "std")]
+use crate::buffer::BufferWriter;
 use crate::column_value::{ColumnValue, RowData};
 use crate::error::{ReplicationError, Result};
-use crate::types::{
-    format_lsn, system_time_to_postgres_timestamp, Oid, TimestampTz, XLogRecPtr, Xid,
-};
+use crate::prelude::*;
+#[cfg(feature = "std")]
+use crate::types::system_time_to_postgres_timestamp;
+use crate::types::{format_lsn, Oid, TimestampTz, XLogRecPtr, Xid};
 use bytes::Bytes;
 use serde::{Deserialize, Serialize};
 use smallvec::SmallVec;
-use std::borrow::Cow;
-use std::collections::HashMap;
-use std::hash::{BuildHasherDefault, Hasher};
-use std::sync::Arc;
+#[cfg(feature = "std")]
 use std::time::SystemTime;
 use tracing::debug;
 
-/// Identity hasher for `u32` OIDs.
-///
-/// PostgreSQL OIDs are already 32 bits of good entropy, so a full hash is
-/// wasted work. This hasher passes the OID through to the lower bits of the
-/// returned `u64`, eliminating SipHash overhead on the per-row hot path.
-#[derive(Default)]
-pub struct OidHasher(u64);
-
-impl Hasher for OidHasher {
-    #[inline(always)]
-    fn finish(&self) -> u64 {
-        self.0
-    }
-
-    #[inline(always)]
-    fn write(&mut self, bytes: &[u8]) {
-        // HashMap::get::<&u32> routes through write_u32, so this should not fire
-        // on the hot path; handle it defensively by hashing tail bytes.
-        for &b in bytes {
-            self.0 = self.0.rotate_left(8) ^ u64::from(b);
-        }
-    }
-
-    #[inline(always)]
-    fn write_u32(&mut self, n: u32) {
-        self.0 = u64::from(n);
-    }
-
-    #[inline(always)]
-    fn write_u64(&mut self, n: u64) {
-        self.0 = n;
-    }
-}
-
-/// `HashMap` keyed by `Oid` using the identity hasher.
-pub type RelationMap = HashMap<Oid, RelationInfo, BuildHasherDefault<OidHasher>>;
+/// Map of relations keyed by `Oid`.
+pub type RelationMap = BTreeMap<Oid, RelationInfo>;
 
 /// Message type constants for logical replication protocol
 pub mod message_types {
@@ -444,7 +410,7 @@ impl ColumnData {
             return None;
         }
 
-        match std::str::from_utf8(&self.data) {
+        match core::str::from_utf8(&self.data) {
             Ok(s) => Some(Cow::Borrowed(s)),
             Err(_) => {
                 // Fallback: Use lossy conversion (rare case)
@@ -598,6 +564,7 @@ pub struct ReplicationState {
     /// Last applied LSN
     pub last_applied_lsn: XLogRecPtr,
     /// Last feedback time
+    #[cfg(feature = "std")]
     pub last_feedback_time: std::time::Instant,
     /// Last LSN values sent in feedback (for throttling)
     last_sent_flush_lsn: XLogRecPtr,
@@ -608,10 +575,11 @@ impl ReplicationState {
     #[inline]
     pub fn new() -> Self {
         Self {
-            relations: RelationMap::with_capacity_and_hasher(64, BuildHasherDefault::default()),
+            relations: RelationMap::new(),
             last_received_lsn: 0,
             last_flushed_lsn: 0,
             last_applied_lsn: 0,
+            #[cfg(feature = "std")]
             last_feedback_time: std::time::Instant::now(),
             last_sent_flush_lsn: 0,
             last_sent_applied_lsn: 0,
@@ -657,6 +625,7 @@ impl ReplicationState {
         }
     }
 
+    #[cfg(feature = "std")]
     /// Check if the configured feedback interval has elapsed since the last feedback was sent.
     #[inline]
     pub fn should_send_feedback(&self, interval: std::time::Duration) -> bool {
@@ -669,13 +638,22 @@ impl ReplicationState {
         flush_lsn != self.last_sent_flush_lsn || applied_lsn != self.last_sent_applied_lsn
     }
 
-    /// Mark feedback as sent and record the LSN values sent
-    pub fn mark_feedback_sent_with_lsn(&mut self, flush_lsn: XLogRecPtr, applied_lsn: XLogRecPtr) {
-        self.last_feedback_time = std::time::Instant::now();
+    /// Record the LSN values reported in the last status update. Available in
+    /// `no_std` so a consumer with its own transport can drive `lsn_has_changed`.
+    #[inline]
+    pub fn record_sent_lsns(&mut self, flush_lsn: XLogRecPtr, applied_lsn: XLogRecPtr) {
         self.last_sent_flush_lsn = flush_lsn;
         self.last_sent_applied_lsn = applied_lsn;
     }
 
+    #[cfg(feature = "std")]
+    /// Mark feedback as sent and record the LSN values sent
+    pub fn mark_feedback_sent_with_lsn(&mut self, flush_lsn: XLogRecPtr, applied_lsn: XLogRecPtr) {
+        self.last_feedback_time = std::time::Instant::now();
+        self.record_sent_lsns(flush_lsn, applied_lsn);
+    }
+
+    #[cfg(feature = "std")]
     /// Mark feedback as sent (backward compatibility)
     pub fn mark_feedback_sent(&mut self) {
         self.last_feedback_time = std::time::Instant::now();
@@ -1410,6 +1388,7 @@ pub struct KeepaliveMessage {
 /// - Int32: xmin epoch
 /// - Int32: catalog_xmin
 /// - Int32: catalog_xmin epoch
+#[cfg(feature = "std")]
 pub fn build_hot_standby_feedback_message(
     xmin: u32,
     xmin_epoch: u32,
@@ -2220,6 +2199,16 @@ mod tests {
         // But different values should
         assert!(state.lsn_has_changed(600, 300));
         assert!(state.lsn_has_changed(500, 400));
+    }
+
+    #[test]
+    fn test_replication_state_record_sent_lsns_dedup() {
+        // The no_std dedup flow: lsn_has_changed plus record_sent_lsns, no clock.
+        let mut state = ReplicationState::new();
+        assert!(state.lsn_has_changed(700, 400));
+        state.record_sent_lsns(700, 400);
+        assert!(!state.lsn_has_changed(700, 400));
+        assert!(state.lsn_has_changed(800, 400));
     }
 
     #[test]

--- a/src/sql_builder.rs
+++ b/src/sql_builder.rs
@@ -6,6 +6,7 @@
 //! to avoid intermediate allocations.
 
 use crate::error::{ReplicationError, Result};
+use crate::prelude::*;
 use crate::types::{
     format_lsn, BaseBackupOptions, ReplicationSlotOptions, SlotType, XLogRecPtr,
     INVALID_XLOG_REC_PTR,

--- a/src/types.rs
+++ b/src/types.rs
@@ -5,11 +5,11 @@
 
 use crate::buffer::BufferReader;
 use crate::error::{ReplicationError, Result};
+use crate::prelude::*;
 use crate::protocol::message_types;
 use bytes::{Bytes, BytesMut};
 use serde::{Deserialize, Serialize};
-use std::collections::HashMap;
-use std::sync::Arc;
+#[cfg(feature = "std")]
 use std::time::{SystemTime, UNIX_EPOCH};
 
 // PostgreSQL constants
@@ -82,7 +82,7 @@ impl<T> CachePadded<T> {
     }
 }
 
-impl<T> std::ops::Deref for CachePadded<T> {
+impl<T> core::ops::Deref for CachePadded<T> {
     type Target = T;
 
     fn deref(&self) -> &Self::Target {
@@ -90,12 +90,13 @@ impl<T> std::ops::Deref for CachePadded<T> {
     }
 }
 
-impl<T> std::ops::DerefMut for CachePadded<T> {
+impl<T> core::ops::DerefMut for CachePadded<T> {
     fn deref_mut(&mut self) -> &mut Self::Target {
         &mut self.value
     }
 }
 
+#[cfg(feature = "std")]
 /// Convert SystemTime to PostgreSQL timestamp format (microseconds since 2000-01-01)
 ///
 /// PostgreSQL uses a different epoch than Unix (2000-01-01 vs 1970-01-01).
@@ -322,8 +323,8 @@ impl SlotType {
     }
 }
 
-impl std::fmt::Display for SlotType {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for SlotType {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", self.as_str())
     }
 }
@@ -437,7 +438,7 @@ impl Lsn {
 }
 
 /// Parse LSN from PostgreSQL string format (e.g., "16/B374D848")
-impl std::str::FromStr for Lsn {
+impl core::str::FromStr for Lsn {
     type Err = ReplicationError;
 
     fn from_str(s: &str) -> Result<Self> {
@@ -445,8 +446,8 @@ impl std::str::FromStr for Lsn {
     }
 }
 
-impl std::fmt::Display for Lsn {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl core::fmt::Display for Lsn {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         write!(f, "{}", format_lsn(self.0))
     }
 }
@@ -633,7 +634,7 @@ pub struct ChangeEvent {
     pub lsn: Lsn,
 
     /// Additional user-defined metadata (key-value string pairs).
-    pub metadata: Option<HashMap<String, String>>,
+    pub metadata: Option<BTreeMap<String, String>>,
 }
 
 impl ChangeEvent {
@@ -1097,7 +1098,7 @@ impl ChangeEvent {
     }
 
     /// Set metadata for this event
-    pub fn with_metadata(mut self, metadata: HashMap<String, String>) -> Self {
+    pub fn with_metadata(mut self, metadata: BTreeMap<String, String>) -> Self {
         self.metadata = Some(metadata);
         self
     }
@@ -1577,7 +1578,7 @@ impl ChangeEvent {
         let has_meta = reader.read_u8()?;
         let metadata = if has_meta != 0 {
             let count = reader.read_u16()? as usize;
-            let mut m = HashMap::with_capacity(count);
+            let mut m = BTreeMap::new();
             for _ in 0..count {
                 let k = decode_string(&mut reader)?;
                 let v = decode_string(&mut reader)?;
@@ -1902,7 +1903,7 @@ fn encode_arc_str(buf: &mut BytesMut, s: &Arc<str>) {
 fn decode_arc_str(reader: &mut BufferReader) -> Result<Arc<str>> {
     let len = reader.read_u16()? as usize;
     let bytes = reader.read_bytes(len)?;
-    let s = std::str::from_utf8(&bytes)
+    let s = core::str::from_utf8(&bytes)
         .map_err(|e| ReplicationError::protocol(format!("Invalid UTF-8 in wire format: {e}")))?;
     Ok(Arc::from(s))
 }
@@ -2335,7 +2336,7 @@ mod tests {
         let event = ChangeEvent::insert("public", "test", 1, data, Lsn::new(100));
         assert!(event.metadata.is_none());
 
-        let mut metadata = HashMap::new();
+        let mut metadata = BTreeMap::new();
         metadata.insert("source".to_string(), "test".to_string());
         metadata.insert("version".to_string(), "2".to_string());
 
@@ -2513,18 +2514,8 @@ mod tests {
         let decoded = ChangeEvent::decode(&buf).expect("decode failed");
         assert_eq!(decoded.lsn, event.lsn);
         assert_eq!(decoded.event_type, event.event_type);
-        // Compare metadata (HashMap doesn't impl Eq but we can check the content)
-        assert_eq!(
-            decoded.metadata.is_some(),
-            event.metadata.is_some(),
-            "metadata presence mismatch"
-        );
-        if let (Some(a), Some(b)) = (&decoded.metadata, &event.metadata) {
-            assert_eq!(a.len(), b.len());
-            for (k, v) in b {
-                assert_eq!(a.get(k), Some(v));
-            }
-        }
+        // BTreeMap implements Eq, so compare metadata directly.
+        assert_eq!(decoded.metadata, event.metadata);
     }
 
     #[test]
@@ -2541,7 +2532,7 @@ mod tests {
     #[test]
     fn test_encode_decode_insert_with_metadata() {
         let data = RowData::from_pairs(vec![("x", ColumnValue::text("1"))]);
-        let mut meta = HashMap::new();
+        let mut meta = BTreeMap::new();
         meta.insert("source".to_string(), "unit-test".to_string());
         meta.insert("version".to_string(), "3".to_string());
         let event =
@@ -2928,7 +2919,7 @@ mod tests {
     fn test_encode_decode_metadata_empty_hashmap() {
         let data = RowData::from_pairs(vec![("a", ColumnValue::text("b"))]);
         let event =
-            ChangeEvent::insert("s", "t", 1, data, Lsn::new(14000)).with_metadata(HashMap::new());
+            ChangeEvent::insert("s", "t", 1, data, Lsn::new(14000)).with_metadata(BTreeMap::new());
         assert_encode_decode_round_trip(&event);
     }
 
@@ -3844,7 +3835,7 @@ mod tests {
     #[test]
     fn test_encode_decode_begin_prepare_with_metadata() {
         let ts = Utc.with_ymd_and_hms(2024, 7, 1, 12, 0, 0).unwrap();
-        let mut meta = HashMap::new();
+        let mut meta = BTreeMap::new();
         meta.insert("source".to_string(), "test".to_string());
         let event = ChangeEvent::begin_prepare(
             42,
@@ -3862,7 +3853,7 @@ mod tests {
     fn test_encode_decode_rollback_prepared_with_metadata() {
         let ts1 = Utc.with_ymd_and_hms(2024, 7, 1, 12, 0, 0).unwrap();
         let ts2 = Utc.with_ymd_and_hms(2024, 7, 1, 12, 5, 0).unwrap();
-        let mut meta = HashMap::new();
+        let mut meta = BTreeMap::new();
         meta.insert("reason".to_string(), "timeout".to_string());
         let event = ChangeEvent::rollback_prepared(
             0,
@@ -3882,7 +3873,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_origin_with_metadata() {
-        let mut meta = HashMap::new();
+        let mut meta = BTreeMap::new();
         meta.insert("cluster".to_string(), "us-east".to_string());
         let event = ChangeEvent::origin(Lsn::new(500), "us_east_origin", Lsn::new(10200))
             .with_metadata(meta);
@@ -3891,7 +3882,7 @@ mod tests {
 
     #[test]
     fn test_encode_decode_type_with_metadata() {
-        let mut meta = HashMap::new();
+        let mut meta = BTreeMap::new();
         meta.insert("schema_version".to_string(), "1".to_string());
         let event = ChangeEvent::type_event(12345, "pg_catalog", "my_enum", Lsn::new(10100))
             .with_metadata(meta);


### PR DESCRIPTION
Makes the protocol parser build in `no_std` plus `alloc` (wasm and embedded) with the default build untouched: `std` is a default feature, `--no-default-features` gives the parser-only build, and the `libpq` and `rustls-tls` backends pull `std`. Builds on the optional `tokio` support from #69.

`RelationMap` and `ChangeEvent.metadata` move to `alloc::collections::BTreeMap` rather than `hashbrown` (no extra crate, benchmarked within noise of the old `HashMap`), and `chrono::DateTime<Utc>` stays the timestamp type with `chrono` at `default-features = false` since the parser builds it from the wire `i64`, never a clock. `SystemTime`, the `Instant` feedback timing, and the `Io`/`StringConversion` error variants are `std`-gated, and CI adds a `wasm32-unknown-unknown` build.

Closes #70.
