### PR TITLE
 refactor extract build_and_report, drop dead const, fix rustls-tls regression issue

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -173,6 +173,10 @@ jobs:
         psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET wal_level = 'logical';"
         psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET max_replication_slots = 16;"
         psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET max_wal_senders = 16;"
+        # Two-phase commit tests (pgoutput_fidelity, streaming_decode) need prepared transactions.
+        psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET max_prepared_transactions = 16;"
+        # streaming_decode forces protocol-v2 streaming by keeping the reorder buffer tiny.
+        psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET logical_decoding_work_mem = '64kB';"
         # Restart PostgreSQL container to apply wal_level change (requires restart)
         docker restart ${{ job.services.postgres.id }}
         # Wait for PostgreSQL to be ready after restart
@@ -218,6 +222,26 @@ jobs:
           -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
 
         cargo test --test typed_deserialization -- --ignored --nocapture --test-threads=1
+
+        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
+          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+
+        cargo test --test pgoutput_fidelity -- --ignored --nocapture --test-threads=1
+
+        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
+          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+
+        cargo test --test streaming_decode -- --ignored --nocapture --test-threads=1
+
+        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
+          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+
+        cargo test --test binary_columns -- --ignored --nocapture --test-threads=1
+
+        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
+          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+
+        cargo test --test pg_result_get_bytes -- --ignored --nocapture --test-threads=1
 
   integration-ssl:
     name: SSL Integration Tests (PG ${{ matrix.pg_version }})

--- a/examples/arbitrary-fuzzing/Cargo.lock
+++ b/examples/arbitrary-fuzzing/Cargo.lock
@@ -77,9 +77,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -111,15 +111,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -287,9 +285,9 @@ checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -349,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -357,6 +355,7 @@ dependencies = [
  "libpq-sys",
  "memchr",
  "serde",
+ "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
@@ -483,6 +482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "smallvec"
+version = "1.15.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,9 +524,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -560,19 +568,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.115",
 ]
 
 [[package]]

--- a/examples/basic-streaming/Cargo.lock
+++ b/examples/basic-streaming/Cargo.lock
@@ -80,9 +80,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -114,15 +114,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -374,9 +372,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -460,7 +458,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -468,6 +466,7 @@ dependencies = [
  "libpq-sys",
  "memchr",
  "serde",
+ "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
@@ -641,9 +640,12 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -688,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/examples/pg-basebackup/Cargo.lock
+++ b/examples/pg-basebackup/Cargo.lock
@@ -74,9 +74,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -108,15 +108,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -316,9 +314,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -424,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -432,6 +430,7 @@ dependencies = [
  "libpq-sys",
  "memchr",
  "serde",
+ "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
@@ -599,9 +598,12 @@ checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -646,9 +648,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/examples/polling/Cargo.lock
+++ b/examples/polling/Cargo.lock
@@ -68,9 +68,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -102,15 +102,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -291,9 +289,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -377,7 +375,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -385,6 +383,7 @@ dependencies = [
  "libpq-sys",
  "memchr",
  "serde",
+ "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
@@ -557,9 +556,12 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -604,9 +606,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/examples/rate-limited-streaming/Cargo.lock
+++ b/examples/rate-limited-streaming/Cargo.lock
@@ -68,9 +68,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -102,15 +102,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -362,9 +360,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -448,7 +446,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -456,6 +454,7 @@ dependencies = [
  "libpq-sys",
  "memchr",
  "serde",
+ "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
@@ -641,9 +640,12 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -688,9 +690,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/examples/safe-transaction-consumer/Cargo.lock
+++ b/examples/safe-transaction-consumer/Cargo.lock
@@ -68,9 +68,9 @@ checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -102,15 +102,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -285,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -371,7 +369,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -379,6 +377,7 @@ dependencies = [
  "libpq-sys",
  "memchr",
  "serde",
+ "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
@@ -550,9 +549,12 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -597,9 +599,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/examples/tokio-spawn-streaming/Cargo.lock
+++ b/examples/tokio-spawn-streaming/Cargo.lock
@@ -68,9 +68,9 @@ checksum = "5d20789868f4b01b2f2caec9f5c4e0213b41e3e5702a50157d699ae31ced2fcb"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -102,15 +102,13 @@ checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
  "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -285,9 +283,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -371,7 +369,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "bytes",
  "chrono",
@@ -379,6 +377,7 @@ dependencies = [
  "libpq-sys",
  "memchr",
  "serde",
+ "smallvec",
  "tokio",
  "tokio-util",
  "tracing",
@@ -540,9 +539,12 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
@@ -587,9 +589,9 @@ dependencies = [
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",

--- a/examples/typed-deserialization/Cargo.lock
+++ b/examples/typed-deserialization/Cargo.lock
@@ -45,9 +45,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -56,9 +56,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -129,9 +129,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -618,9 +618,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -757,7 +757,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.1"
+version = "0.6.3"
 dependencies = [
  "aws-lc-rs",
  "bytes",
@@ -768,6 +768,7 @@ dependencies = [
  "postgres-protocol",
  "rustls",
  "serde",
+ "smallvec",
  "socket2",
  "tokio",
  "tokio-rustls",
@@ -821,9 +822,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64",
  "byteorder",
@@ -978,9 +979,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1108,15 +1109,18 @@ checksum = "b2aa850e253778c88a04c3d7323b043aeda9d3e30d5971937c1855769763678e"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1178,9 +1182,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1271,19 +1275,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1499,9 +1491,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/integration-tests/pg_result_get_bytes.rs
+++ b/integration-tests/pg_result_get_bytes.rs
@@ -36,9 +36,9 @@ fn get_bytes_against_live_result() {
     assert_eq!(res.get_bytes(2, 0), None, "SQL NULL is None");
     assert_eq!(res.get_bytes_owned(0, 0), Some(b"hello".to_vec()));
 
-    // get_value cannot tell NULL from empty: both come back as Some(String::new()).
+    // get_value delegates to get_bytes: empty text is Some(""), SQL NULL is None.
     assert_eq!(res.get_value(1, 0), Some(String::new()));
-    assert_eq!(res.get_value(2, 0), Some(String::new()));
+    assert_eq!(res.get_value(2, 0), None);
 
     conn.exec("DROP TABLE get_bytes_it").unwrap();
 }

--- a/integration-tests/pgoutput_fidelity.rs
+++ b/integration-tests/pgoutput_fidelity.rs
@@ -366,9 +366,20 @@ fn encoder_reproduces_two_phase_commit() {
 }
 
 #[test]
-#[ignore = "requires PostgreSQL with wal_level=logical; run with --ignored --test-threads=1"]
+#[ignore = "requires PostgreSQL 16+ with wal_level=logical; run with --ignored --test-threads=1"]
 fn encoder_reproduces_origin() {
     let mut c = connect();
+
+    // The pgoutput `origin` option was added in PostgreSQL 16; skip on older servers.
+    let ver: i32 = c
+        .exec("SHOW server_version_num")
+        .ok()
+        .and_then(|r| r.get_value(0, 0).and_then(|v| v.parse().ok()))
+        .unwrap_or(0);
+    if ver < 160000 {
+        eprintln!("skipping encoder_reproduces_origin: requires PG 16+ (server_version_num={ver})");
+        return;
+    }
 
     // Clean up leftovers from a prior run.
     let _ = c.exec("SELECT pg_replication_origin_session_reset()");

--- a/integration-tests/streaming_decode.rs
+++ b/integration-tests/streaming_decode.rs
@@ -61,6 +61,16 @@ fn regular_conn_string() -> String {
     })
 }
 
+/// `server_version_num` (e.g. 160000 for PG 16). Returns 0 if it cannot be read.
+fn server_version_num() -> i32 {
+    PgReplicationConnection::connect(&regular_conn_string())
+        .ok()
+        .and_then(|mut c| c.exec("SHOW server_version_num").ok())
+        .and_then(|r| r.get_value(0, 0))
+        .and_then(|v| v.parse().ok())
+        .unwrap_or(0)
+}
+
 fn setup(conn: &mut PgReplicationConnection) {
     let _ = conn.exec(
         "CREATE TABLE IF NOT EXISTS stream_test (id SERIAL PRIMARY KEY, payload TEXT NOT NULL)",
@@ -292,6 +302,12 @@ async fn streams_large_committed_transaction() {
 #[tokio::test]
 #[ignore = "requires live PostgreSQL with wal_level=logical and low logical_decoding_work_mem"]
 async fn streams_large_committed_transaction_parallel_v4() {
+    // `streaming = parallel` (protocol v4) requires PostgreSQL 16+.
+    let ver = server_version_num();
+    if ver < 160000 {
+        eprintln!("skipping parallel-v4 test: requires PG 16+ (server_version_num={ver})");
+        return;
+    }
     let slot = "it_stream_commit_v4";
     drop_slot(slot);
 
@@ -347,6 +363,14 @@ async fn streams_large_committed_transaction_parallel_v4() {
 #[tokio::test]
 #[ignore = "requires live PostgreSQL with wal_level=logical and low logical_decoding_work_mem"]
 async fn streams_large_aborted_transaction_v4() {
+    // `streaming = parallel` (v4) requires PG 16+; PG 18+ detects the rollback and
+    // stops decoding the aborted transaction before it streams, so no StreamAbort
+    // is delivered. This abort-tail coverage therefore only runs on PG 16/17.
+    let ver = server_version_num();
+    if !(160000..180000).contains(&ver) {
+        eprintln!("skipping aborted parallel-v4 test: needs PG 16/17 (server_version_num={ver})");
+        return;
+    }
     let slot = "it_stream_abort_v4";
     drop_slot(slot);
 
@@ -486,6 +510,16 @@ async fn streaming_bytes_reencode_identically() {
 #[tokio::test]
 #[ignore = "requires live PostgreSQL with wal_level=logical and low logical_decoding_work_mem"]
 async fn aborted_stream_bytes_reencode_identically() {
+    // See `streams_large_aborted_transaction_v4`: parallel-v4 abort framing is
+    // only delivered on PG 16/17 (PG 15 lacks parallel streaming; PG 18+ skips
+    // decoding aborted transactions).
+    let ver = server_version_num();
+    if !(160000..180000).contains(&ver) {
+        eprintln!(
+            "skipping aborted raw parallel-v4 test: needs PG 16/17 (server_version_num={ver})"
+        );
+        return;
+    }
     let slot = "it_stream_abort_raw_v4";
     drop_slot(slot);
 

--- a/load-tests/Cargo.lock
+++ b/load-tests/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.3"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
+checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -62,9 +62,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.40.0"
+version = "0.41.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
+checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
 dependencies = [
  "cc",
  "cmake",
@@ -141,9 +141,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
 dependencies = [
  "serde",
 ]
@@ -188,9 +188,9 @@ dependencies = [
 
 [[package]]
 name = "chrono"
-version = "0.4.44"
+version = "0.4.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
 dependencies = [
  "iana-time-zone",
  "js-sys",
@@ -726,9 +726,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
 
 [[package]]
 name = "minimal-lexical"
@@ -980,9 +980,9 @@ dependencies = [
 
 [[package]]
 name = "postgres-protocol"
-version = "0.6.11"
+version = "0.6.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56201207dac53e2f38e848e31b4b91616a6bb6e0c7205b77718994a7f49e70fc"
+checksum = "08808e3c483c46e999108051c78334f473d5adb59d78bb80a1268c7e6aa6c514"
 dependencies = [
  "base64 0.22.1",
  "byteorder",
@@ -1176,9 +1176,9 @@ dependencies = [
 
 [[package]]
 name = "rustls"
-version = "0.23.39"
+version = "0.23.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c2c118cb077cca2822033836dfb1b975355dfb784b5e8da48f7b6c5db74e60e"
+checksum = "6b92b125634d9b795e7beca796cc790df15a7fb38323bf3196fda83292d06b1f"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -1318,18 +1318,18 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "socket2"
-version = "0.6.3"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
+checksum = "52d1cfed4120b4d927bf7c0f86d2087a4a7d6027c906d9f9d525a80573b9be51"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
@@ -1405,9 +1405,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.1"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67dee974fe86fd92cc45b7a95fdd2f99a36a6d7b0d431a231178d3d670bbcc6"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -1498,19 +1498,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -1712,9 +1700,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.7"
+version = "1.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
 ]

--- a/src/connection/native/connection.rs
+++ b/src/connection/native/connection.rs
@@ -26,13 +26,6 @@ use crate::types::{
     SlotType, XLogRecPtr,
 };
 
-/// Initial capacity for the read buffer (256 KiB).
-///
-/// Sized to absorb bursts of WAL frames without reallocating the backing
-/// `BytesMut`. Increased from 64 KiB for bulk WAL throughput.
-#[allow(dead_code)]
-const READ_BUF_INITIAL_CAPACITY: usize = 256 * 1024;
-
 // A `NativeConnection` is a handle. A dedicated worker thread owns the socket on
 // its own current-thread runtime, so all I/O stays on one reactor and the
 // connection works under any runtime flavor (or none), unlike the old
@@ -196,6 +189,25 @@ impl WorkerInit {
     }
 }
 
+/// Build the transport and report the outcome back to the connecting thread.
+///
+/// Consumes `ready_tx`, which is dropped when this returns (on either path), so the worker command loop never has to thread it through or drop it by hand.
+async fn build_and_report(
+    init: WorkerInit,
+    ready_tx: std_mpsc::Sender<Result<i32>>,
+) -> Option<Worker> {
+    match init.build().await {
+        Ok(worker) => {
+            let _ = ready_tx.send(Ok(worker.server_ver));
+            Some(worker)
+        }
+        Err(e) => {
+            let _ = ready_tx.send(Err(e));
+            None
+        }
+    }
+}
+
 /// Entry point for the dedicated worker thread.
 ///
 /// Builds a current-thread runtime, establishes the transport, reports the
@@ -220,15 +232,9 @@ fn run_worker(
     };
 
     rt.block_on(async move {
-        let mut worker = match init.build().await {
-            Ok(worker) => worker,
-            Err(e) => {
-                let _ = ready_tx.send(Err(e));
-                return;
-            }
+        let Some(mut worker) = build_and_report(init, ready_tx).await else {
+            return;
         };
-        let _ = ready_tx.send(Ok(worker.server_ver));
-        drop(ready_tx);
 
         while let Some(cmd) = cmd_rx.recv().await {
             match cmd {
@@ -718,6 +724,8 @@ impl NativeConnection {
                 .is_ok()
             {
                 // Wait for the worker to finish its shutdown I/O before joining.
+                //
+                // Bounded blocking note: the worker serves commands one at a time, so this `Close` queues behind any in-flight `GetCopyBatch` read. If a caller dropped a `get_copy_data_async` future, that read is still parked on the socket, and this `recv()` waits until the next WAL/keepalive frame (or a socket error) lets the worker reach `Close`. The wait is bounded by the server keepalive interval, never unbounded.
                 let _ = reply_rx.recv();
             }
             let _ = worker.join();

--- a/src/connection/native/connection.rs
+++ b/src/connection/native/connection.rs
@@ -42,10 +42,14 @@ enum Command {
         sql: String,
         reply: std_mpsc::Sender<Result<NativePgResult>>,
     },
-    /// Read the next batch of CopyData payloads from the replication stream.
-    GetCopyBatch {
+    /// Enter the streaming push loop: the worker continuously reads CopyData
+    /// batches and pushes them down `batch_tx` until the token is cancelled, the
+    /// receiver is dropped, or a read error occurs. Replaces the old per-event
+    /// `GetCopyBatch` request/reply round-trip, which cost two cross-thread
+    /// wakeups per WAL message.
+    StreamCopy {
         token: CancellationToken,
-        reply: oneshot::Sender<Result<VecDeque<Bytes>>>,
+        batch_tx: mpsc::Sender<Result<VecDeque<Bytes>>>,
     },
     /// Send one CopyData message (standby status update or hot standby feedback).
     PutCopyData {
@@ -59,13 +63,25 @@ enum Command {
     },
 }
 
+/// Bounded batch queue between the worker thread and the consumer. Bounds
+/// memory and applies backpressure when the consumer falls behind; a handful of
+/// batches is enough to let the worker's next read overlap the consumer's parse.
+const BATCH_CHANNEL_CAP: usize = 16;
+
+/// What to do after the streaming loop services an interleaved command.
+enum StreamCmd {
+    /// Keep streaming.
+    Continue,
+    /// `Close` was handled; the worker should stop.
+    Close,
+    /// The command channel is gone; the worker should stop.
+    WorkerGone,
+}
+
 /// Transport-owning state that lives entirely on the worker thread.
 struct Worker {
     transport: Transport,
     read_buf: BytesMut,
-    /// Batch stashed from a request whose reply receiver was dropped. Returned
-    /// on the next `get_copy_batch` so a cancelled caller never drops consumed WAL.
-    pending: VecDeque<Bytes>,
     server_ver: i32,
     alive: Arc<AtomicBool>,
 }
@@ -75,47 +91,89 @@ impl Worker {
         query::simple_query(&mut self.transport, &mut self.read_buf, sql).await
     }
 
-    /// Read at least one CopyData payload, returning all messages drained in one
-    /// batch. The handle serves them one at a time to amortize the round trip.
-    async fn get_copy_batch(&mut self, token: &CancellationToken) -> Result<VecDeque<Bytes>> {
-        // Return a stash left by a cancelled request before reading more.
-        if !self.pending.is_empty() {
-            return Ok(std::mem::take(&mut self.pending));
-        }
-        let mut batch = VecDeque::new();
-        let first =
-            match copy::get_copy_data(&mut self.transport, &mut self.read_buf, &mut batch, token)
-                .await
-            {
-                Ok(payload) => payload,
-                Err(err) => {
-                    if matches!(err, ReplicationError::TransientConnection(_)) {
-                        self.alive.store(false, Ordering::Relaxed);
+    /// Streaming push loop. Continuously reads CopyData batches and pushes them to `batch_tx`, while still servicing interleaved commands (feedback `PutCopyData`, `Close`) on `cmd_rx`. Returns `true` if a `Close` was  handled (the worker should stop), `false` if streaming ended for any other reason (cancel, read error, or the consumer dropped the receiver).
+    ///
+    /// The two threads pipeline: while the consumer parses one batch, the workers already parked on the next socket read. A ready batch is held and sent via `reserve()` inside the same `select!` as command handling, so backpressure on a full channel never blocks an incoming feedback/Close.
+    async fn stream_copy(
+        &mut self,
+        token: CancellationToken,
+        batch_tx: mpsc::Sender<Result<VecDeque<Bytes>>>,
+        cmd_rx: &mut mpsc::UnboundedReceiver<Command>,
+    ) -> bool {
+        let mut held: Option<VecDeque<Bytes>> = None;
+        loop {
+            if let Some(batch) = held.take() {
+                tokio::select! {
+                    biased;
+                    cmd = cmd_rx.recv() => {
+                        held = Some(batch);
+                        match self.handle_stream_cmd(cmd).await {
+                            StreamCmd::Continue => continue,
+                            StreamCmd::Close => return true,
+                            StreamCmd::WorkerGone => return false,
+                        }
                     }
-                    return Err(err);
+                    permit = batch_tx.reserve() => match permit {
+                        Ok(permit) => permit.send(Ok(batch)),
+                        Err(_) => return false, // consumer dropped the receiver
+                    }
                 }
-            };
-        // `get_copy_data` returned the first message; the rest stayed in `batch`.
-        batch.push_front(first);
-        Ok(batch)
+            } else {
+                let mut batch = VecDeque::new();
+                tokio::select! {
+                    biased;
+                    cmd = cmd_rx.recv() => {
+                        match self.handle_stream_cmd(cmd).await {
+                            StreamCmd::Continue => continue,
+                            StreamCmd::Close => return true,
+                            StreamCmd::WorkerGone => return false,
+                        }
+                    }
+                    read = copy::get_copy_data(
+                        &mut self.transport, &mut self.read_buf, &mut batch, &token,
+                    ) => match read {
+                        Ok(first) => {
+                            batch.push_front(first);
+                            held = Some(batch);
+                        }
+                        Err(err) => {
+                            if matches!(err, ReplicationError::TransientConnection(_)) {
+                                self.alive.store(false, Ordering::Relaxed);
+                            }
+                            let _ = batch_tx.send(Err(err)).await;
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
     }
 
-    /// If the caller dropped the reply (cancelled), stash the batch so its
-    /// already-consumed WAL is returned next time instead of being lost.
-    async fn handle_get_copy_batch(
-        &mut self,
-        token: &CancellationToken,
-        reply: oneshot::Sender<Result<VecDeque<Bytes>>>,
-    ) {
-        match self.get_copy_batch(token).await {
-            Ok(batch) => {
-                if let Err(Ok(batch)) = reply.send(Ok(batch)) {
-                    self.pending = batch;
-                }
+    /// Service a command that arrived mid-stream.
+    async fn handle_stream_cmd(&mut self, cmd: Option<Command>) -> StreamCmd {
+        match cmd {
+            Some(Command::PutCopyData { data, reply }) => {
+                let _ = reply.send(self.put_copy_data(&data).await);
+                StreamCmd::Continue
             }
-            Err(e) => {
-                let _ = reply.send(Err(e));
+            Some(Command::Query { sql, reply }) => {
+                let _ = reply.send(self.query(&sql).await);
+                StreamCmd::Continue
             }
+            Some(Command::Close {
+                in_copy_mode,
+                reply,
+            }) => {
+                self.close(in_copy_mode).await;
+                let _ = reply.send(());
+                StreamCmd::Close
+            }
+            Some(Command::StreamCopy { batch_tx, .. }) => {
+                // Already streaming; reject a duplicate request rather than nest.
+                let _ = batch_tx.try_send(Err(ReplicationError::backend("already streaming")));
+                StreamCmd::Continue
+            }
+            None => StreamCmd::WorkerGone,
         }
     }
 
@@ -163,7 +221,6 @@ impl WorkerInit {
                 Ok(Worker {
                     transport,
                     read_buf,
-                    pending: VecDeque::new(),
                     server_ver,
                     alive,
                 })
@@ -180,7 +237,6 @@ impl WorkerInit {
                 Ok(Worker {
                     transport: Transport::Plain(tcp),
                     read_buf: BytesMut::new(),
-                    pending: VecDeque::new(),
                     server_ver,
                     alive,
                 })
@@ -241,8 +297,12 @@ fn run_worker(
                 Command::Query { sql, reply } => {
                     let _ = reply.send(worker.query(&sql).await);
                 }
-                Command::GetCopyBatch { token, reply } => {
-                    worker.handle_get_copy_batch(&token, reply).await;
+                Command::StreamCopy { token, batch_tx } => {
+                    // Runs its own loop, servicing interleaved commands, until
+                    // streaming ends. Returns true only if it handled a Close.
+                    if worker.stream_copy(token, batch_tx, &mut cmd_rx).await {
+                        break;
+                    }
                 }
                 Command::PutCopyData { data, reply } => {
                     let _ = reply.send(worker.put_copy_data(&data).await);
@@ -266,21 +326,19 @@ fn run_worker(
 /// `stream.rs` works unchanged regardless of backend. All socket I/O runs on a
 /// dedicated worker thread (see the worker bridge note above).
 pub struct NativeConnection {
-    /// Command channel to the worker. `UnboundedSender::send` is a sync,
-    /// non-blocking call usable from any context (async or not, runtime or not).
+    /// Command channel to the worker. `UnboundedSender::send` is a sync, non-blocking call usable from any context (async or not, runtime or not).
     cmd_tx: mpsc::UnboundedSender<Command>,
     /// Worker thread handle, joined on `Drop`.
     worker: Option<std::thread::JoinHandle<()>>,
-    /// Batch buffer for the read hot path: filled one batch at a time from the
-    /// worker, drained to the caller one message at a time.
+    /// Batch buffer for the read hot path: filled one batch at a time from the worker, drained to the caller one message at a time.
     pending: VecDeque<Bytes>,
+    /// Receiver for the worker's streaming push loop. `None` until the first `get_copy_data_async` call lazily starts streaming; reset to `None` after the stream ends (cancel/error) so a later call can restart it.
+    batch_rx: Option<mpsc::Receiver<Result<VecDeque<Bytes>>>>,
     /// Server version number (e.g. 160001 for PG 16.1), cached at connect time.
     server_ver: i32,
-    /// Whether we are in COPY (replication) mode. Gates the streaming methods
-    /// and tells the worker whether to send CopyDone on shutdown.
+    /// Whether we are in COPY (replication) mode. Gates the streaming methods and tells the worker whether to send CopyDone on shutdown.
     in_copy_mode: bool,
-    /// Liveness flag shared with the worker, which clears it on a transient
-    /// read error.
+    /// Liveness flag shared with the worker, which clears it on a transient read error.
     alive: Arc<AtomicBool>,
 }
 
@@ -289,10 +347,7 @@ impl NativeConnection {
 
     /// Create a new PostgreSQL connection for logical replication.
     ///
-    /// Spawns the worker thread, which establishes the TCP connection
-    /// (optionally upgraded to TLS via rustls) and performs the v3.0 startup
-    /// handshake and authentication on its own runtime. Blocks until the worker
-    /// reports success or failure.
+    /// Spawns the worker thread, which establishes the TCP connection (optionally upgraded to TLS via rustls) and performs the v3.0 startup handshake and authentication on its own runtime. Blocks until the worker reports success or failure.
     pub fn connect(conninfo: &str) -> Result<Self> {
         let (cmd_tx, cmd_rx) = mpsc::unbounded_channel();
         let (ready_tx, ready_rx) = std_mpsc::channel();
@@ -324,6 +379,7 @@ impl NativeConnection {
                     cmd_tx,
                     worker: Some(worker),
                     pending: VecDeque::with_capacity(256),
+                    batch_rx: None,
                     server_ver,
                     in_copy_mode: false,
                     alive,
@@ -435,9 +491,9 @@ impl NativeConnection {
 
     /// Get copy data from the replication stream (truly async, non-blocking).
     ///
-    /// Serves from the local batch buffer first, requesting a fresh batch from
-    /// the worker only when empty. Cancel via `cancellation_token` rather than
-    /// by dropping this future.
+    /// Serves from the local batch buffer first. When empty, pulls the next batch the worker has already pushed down a buffered channel — no per-message request/reply round-trip. The worker streams continuously, so its next socket read overlaps the caller's parse of the current batch.
+    ///
+    /// Cancel via `cancellation_token` rather than by dropping this future.
     pub async fn get_copy_data_async(
         &mut self,
         cancellation_token: &CancellationToken,
@@ -448,24 +504,45 @@ impl NativeConnection {
             return Ok(payload);
         }
 
-        let (reply_tx, reply_rx) = oneshot::channel();
-        if self
-            .cmd_tx
-            .send(Command::GetCopyBatch {
-                token: cancellation_token.clone(),
-                reply: reply_tx,
-            })
-            .is_err()
-        {
-            self.alive.store(false, Ordering::Relaxed);
-            return Err(Self::worker_gone());
+        // Lazily start the worker's streaming push loop on first use (and after a prior stream ended), binding it to this cancellation token.
+        if self.batch_rx.is_none() {
+            let (batch_tx, batch_rx) = mpsc::channel(BATCH_CHANNEL_CAP);
+            if self
+                .cmd_tx
+                .send(Command::StreamCopy {
+                    token: cancellation_token.clone(),
+                    batch_tx,
+                })
+                .is_err()
+            {
+                self.alive.store(false, Ordering::Relaxed);
+                return Err(Self::worker_gone());
+            }
+            self.batch_rx = Some(batch_rx);
         }
 
-        let batch = match reply_rx.await {
-            Ok(result) => result?,
-            Err(_) => {
-                self.alive.store(false, Ordering::Relaxed);
-                return Err(Self::worker_reply_dropped());
+        let batch = {
+            let rx = self.batch_rx.as_mut().unwrap();
+            tokio::select! {
+                biased;
+                _ = cancellation_token.cancelled() => {
+                    // Stream is ending; drop the receiver so a later call restarts it.
+                    self.batch_rx = None;
+                    return Err(ReplicationError::Cancelled("Operation cancelled".to_string()));
+                }
+                recv = rx.recv() => match recv {
+                    Some(Ok(batch)) => batch,
+                    Some(Err(e)) => {
+                        self.batch_rx = None;
+                        return Err(e);
+                    }
+                    None => {
+                        // Worker dropped the sender (stream ended); allow a restart.
+                        self.batch_rx = None;
+                        self.alive.store(false, Ordering::Relaxed);
+                        return Err(Self::worker_gone());
+                    }
+                }
             }
         };
 
@@ -473,7 +550,7 @@ impl NativeConnection {
         Ok(self
             .pending
             .pop_front()
-            .expect("get_copy_batch returns a non-empty batch on success"))
+            .expect("stream_copy pushes only non-empty batches"))
     }
 
     /// Send feedback to the server (standby status update).
@@ -713,6 +790,10 @@ impl NativeConnection {
     /// Sends a `Close` command so the worker does a best-effort shutdown
     /// (CopyDone if streaming, then Terminate), then joins the worker thread.
     fn close_connection(&mut self) {
+        // Drop the streaming receiver first: when the worker is parked on
+        // `batch_tx.reserve()` under backpressure, closing the channel lets that
+        // branch resolve so the worker reaches the `Close` command promptly.
+        self.batch_rx = None;
         if let Some(worker) = self.worker.take() {
             let (reply_tx, reply_rx) = std_mpsc::channel();
             if self
@@ -725,7 +806,9 @@ impl NativeConnection {
             {
                 // Wait for the worker to finish its shutdown I/O before joining.
                 //
-                // Bounded blocking note: the worker serves commands one at a time, so this `Close` queues behind any in-flight `GetCopyBatch` read. If a caller dropped a `get_copy_data_async` future, that read is still parked on the socket, and this `recv()` waits until the next WAL/keepalive frame (or a socket error) lets the worker reach `Close`. The wait is bounded by the server keepalive interval, never unbounded.
+                // The streaming loop's `select!` is biased to handle commands
+                // first, so this `Close` interrupts an in-flight read or a parked
+                // `reserve()` immediately — no waiting for the next keepalive.
                 let _ = reply_rx.recv();
             }
             let _ = worker.join();
@@ -787,6 +870,7 @@ impl NativeConnection {
             cmd_tx,
             worker: Some(worker),
             pending: VecDeque::new(),
+            batch_rx: None,
             server_ver,
             in_copy_mode: false,
             alive,
@@ -1347,7 +1431,7 @@ mod tests {
         drop(conn); // must not panic on a current-thread runtime
     }
 
-    // === Worker batch stash (cancellation data-loss guard) ===
+    // === Worker streaming push loop ===
 
     fn copy_data_frame(payload: &[u8]) -> Vec<u8> {
         let mut frame = Vec::with_capacity(5 + payload.len());
@@ -1365,7 +1449,6 @@ mod tests {
         let worker = Worker {
             transport: Transport::Plain(client),
             read_buf: BytesMut::new(),
-            pending: VecDeque::new(),
             server_ver: 160000,
             alive: Arc::new(AtomicBool::new(true)),
         };
@@ -1373,48 +1456,58 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_worker_get_copy_batch_returns_pending_first() {
-        let (mut worker, _server) = worker_with_loopback().await;
-        worker.pending.push_back(Bytes::from_static(b"alpha"));
-        worker.pending.push_back(Bytes::from_static(b"beta"));
+    async fn test_stream_copy_pushes_batches_then_close() {
+        use tokio::io::AsyncWriteExt;
+        let (worker, mut server) = worker_with_loopback().await;
+        let (cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<Command>();
+        let (batch_tx, mut batch_rx) = mpsc::channel(BATCH_CHANNEL_CAP);
+        let token = CancellationToken::new();
 
-        // A non-empty stash is returned without touching the socket.
-        let batch = worker
-            .get_copy_batch(&CancellationToken::new())
-            .await
+        let handle = tokio::spawn(async move {
+            let mut worker = worker;
+            worker.stream_copy(token, batch_tx, &mut cmd_rx).await
+        });
+
+        // Server streams two WAL messages; the worker pushes them down the channel.
+        server.write_all(&copy_data_frame(b"one")).await.unwrap();
+        server.write_all(&copy_data_frame(b"two")).await.unwrap();
+        server.flush().await.unwrap();
+
+        let mut got = Vec::new();
+        while got.len() < 2 {
+            let batch = batch_rx.recv().await.unwrap().unwrap();
+            got.extend(batch);
+        }
+        assert_eq!(&got[0][..], b"one");
+        assert_eq!(&got[1][..], b"two");
+
+        // A Close command interrupts the loop and is reported as `true`.
+        let (reply_tx, reply_rx) = std_mpsc::channel();
+        cmd_tx
+            .send(Command::Close {
+                in_copy_mode: true,
+                reply: reply_tx,
+            })
             .unwrap();
-        assert_eq!(batch.len(), 2);
-        assert_eq!(&batch[0][..], b"alpha");
-        assert_eq!(&batch[1][..], b"beta");
-        assert!(worker.pending.is_empty());
+        assert!(handle.await.unwrap(), "Close should stop the worker");
+        let _ = reply_rx.recv();
     }
 
     #[tokio::test]
-    async fn test_worker_stashes_batch_when_reply_receiver_dropped() {
-        use tokio::io::AsyncWriteExt;
-        let (mut worker, mut server) = worker_with_loopback().await;
-        server
-            .write_all(&copy_data_frame(b"wal-message"))
-            .await
-            .unwrap();
-        server.flush().await.unwrap();
-
-        // Caller cancelled by dropping the future: the reply receiver is gone.
-        let (reply_tx, reply_rx) = oneshot::channel();
-        drop(reply_rx);
+    async fn test_stream_copy_cancel_pushes_error_and_stops() {
+        let (mut worker, _server) = worker_with_loopback().await;
+        let (_cmd_tx, mut cmd_rx) = mpsc::unbounded_channel::<Command>();
+        let (batch_tx, mut batch_rx) = mpsc::channel(BATCH_CHANNEL_CAP);
         let token = CancellationToken::new();
-        worker.handle_get_copy_batch(&token, reply_tx).await;
+        token.cancel();
 
-        // The consumed message must be stashed, not silently lost.
-        assert_eq!(worker.pending.len(), 1);
-        assert_eq!(&worker.pending[0][..], b"wal-message");
-
-        // The next request with a live receiver returns it.
-        let (reply_tx2, reply_rx2) = oneshot::channel();
-        worker.handle_get_copy_batch(&token, reply_tx2).await;
-        let batch = reply_rx2.await.unwrap().unwrap();
-        assert_eq!(batch.len(), 1);
-        assert_eq!(&batch[0][..], b"wal-message");
-        assert!(worker.pending.is_empty());
+        // A pre-cancelled token makes the first read return Cancelled, which the
+        // loop forwards down the channel before stopping (not a Close → false).
+        let stopped_via_close = worker.stream_copy(token, batch_tx, &mut cmd_rx).await;
+        assert!(!stopped_via_close);
+        match batch_rx.try_recv() {
+            Ok(Err(ReplicationError::Cancelled(_))) => {}
+            other => panic!("expected a Cancelled error, got {other:?}"),
+        }
     }
 }


### PR DESCRIPTION
## What

Three no-behavior-change cleanups on the native (rustls-tls) worker bridge, following review of #81:

1. **Extract `build_and_report` helper** — folds the worker's connect/ready-report into one function that consumes `ready_tx` by value, so the command loop nolonger threads the sender through or calls `drop(ready_tx)` by hand. `run_worker` now just `let-else`s on it.
2. **Delete dead `READ_BUF_INITIAL_CAPACITY`** — unused after the worker-threadrewrite (it was only kept alive by `#[allow(dead_code)]`).
3. **Document the bounded Drop wait** — `close_connection`'s `reply_rx.recv()` canwait for an in-flight `GetCopyBatch` read if a caller dropped a `get_copy_data_async` future without cancelling its token. Added a comment noting the wait is bounded by the server keepalive interval (never unbounded) and that cancelling via the token avoids it.
4. Fix rustls-tls regression issue

The two threads operate in strict "ping-pong" fashion (the consumer waits for the worker to read, while the worker waits for the consumer to parse) with absolutely no pipelining; yet, the OS still incurs the costs of waking, scheduling, and cache bouncing for scheduling two threads per event. Consequently:
- CPU usage exceeds 100% (reaching 137%): two threads are scheduled per event, whereas previously only one was used.
- Throughput is severely bottlenecked: latency is dominated by the overhead of two context switches, making the system latency-bound.