### PR TITLE
  Fix shutdown deadlock in native stream_copy under backpressure

### DIFF
--- a/src/connection/native/connection.rs
+++ b/src/connection/native/connection.rs
@@ -140,7 +140,8 @@ impl Worker {
                             if matches!(err, ReplicationError::TransientConnection(_)) {
                                 self.alive.store(false, Ordering::Relaxed);
                             }
-                            let _ = batch_tx.send(Err(err)).await;
+
+                            let _ = batch_tx.try_send(Err(err));
                             return false;
                         }
                     }


### PR DESCRIPTION
The terminal error path blocked on ; when the worker wedged and starved the Close command. Use try_send so the worker never blocks; channel-close still signals end-of-stream to the consumer.