### PR TITLE
Add zero-copy borrowed deserialization + read-buffer headroom

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -117,3 +117,7 @@ path = "integration-tests/binary_columns.rs"
 [[bench]]
 name = "wal_pipeline"
 harness = false
+
+[[bench]]
+name = "deserialize"
+harness = false

--- a/benches/deserialize.rs
+++ b/benches/deserialize.rs
@@ -185,5 +185,28 @@ fn bench_mixed(c: &mut Criterion) {
     group.finish();
 }
 
-criterion_group!(benches, bench_narrow, bench_wide, bench_mixed);
+// Map consumer: `HashMap<String,String>` (owned keys+values) vs `HashMap<&str,&str>` (fully borrowed). The borrowed-key half only works after switching the map-key deserializer to `visit_borrowed_str` — before that a `&str` key errored. Isolates the field-name / value alloc a map consumer pays.
+fn bench_map(c: &mut Criterion) {
+    use std::collections::HashMap;
+    let row = cols_row(12, 24);
+    let mut group = c.benchmark_group("hashmap12");
+
+    group.bench_function("owned", |b| {
+        b.iter(|| {
+            let m: HashMap<String, String> = black_box(&row).deserialize_into().unwrap();
+            black_box(m);
+        });
+    });
+
+    group.bench_function("borrowed", |b| {
+        b.iter(|| {
+            let m: HashMap<&str, &str> = black_box(&row).deserialize_borrowed().unwrap();
+            black_box(m);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_narrow, bench_wide, bench_mixed, bench_map);
 criterion_main!(benches);

--- a/benches/deserialize.rs
+++ b/benches/deserialize.rs
@@ -1,0 +1,189 @@
+//! Benchmark: owned vs borrowed row deserialization across many row shapes.
+//!
+//! This is the before/after for the borrowed-deserialization optimization.
+//! For every shape, the SAME row is deserialized two ways:
+//!   - `owned`    — text fields are `String` (one heap alloc + memcpy per field)
+//!   - `borrowed` — text fields are `&'de str` (zero alloc, zero copy)
+//!
+//! Shapes cover the axes that matter:
+//!   - field count:  narrow (8) vs wide (24)
+//!   - value size:   short (~6 B), medium (~32 B), large (~1 KiB)
+//!   - mixed types:  ints + strings (only strings benefit from borrowing)
+//!
+//! Run: cargo bench --bench deserialize
+
+#![allow(dead_code)]
+
+use criterion::{criterion_group, criterion_main, BenchmarkId, Criterion};
+use pg_walstream::{ColumnValue, RowData};
+use serde::Deserialize;
+use std::hint::black_box;
+use std::sync::Arc;
+
+// ---------------------------------------------------------------------------
+// Struct shapes — plain fields only (no flatten: flatten buffers into an owned
+// serde `Content`, which would defeat borrowing). One owned + one borrowed
+// struct per width, generated so field lists stay in sync.
+// ---------------------------------------------------------------------------
+
+macro_rules! owned_struct {
+    ($name:ident; $($f:ident),+ $(,)?) => {
+        #[derive(Deserialize)]
+        struct $name {
+            id: u32,
+            $($f: String),+
+        }
+    };
+}
+
+macro_rules! borrowed_struct {
+    ($name:ident; $($f:ident),+ $(,)?) => {
+        #[derive(Deserialize)]
+        struct $name<'a> {
+            id: u32,
+            $(#[serde(borrow)] $f: &'a str),+
+        }
+    };
+}
+
+owned_struct!(Narrow8Owned; c0, c1, c2, c3, c4, c5, c6, c7);
+borrowed_struct!(Narrow8Borrowed; c0, c1, c2, c3, c4, c5, c6, c7);
+
+owned_struct!(Wide24Owned;
+    c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11,
+    c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23);
+borrowed_struct!(Wide24Borrowed;
+    c0, c1, c2, c3, c4, c5, c6, c7, c8, c9, c10, c11,
+    c12, c13, c14, c15, c16, c17, c18, c19, c20, c21, c22, c23);
+
+// Mixed: half ints, half strings — only the string half can borrow.
+#[derive(Deserialize)]
+struct MixedOwned {
+    a: i64,
+    b: i64,
+    c: i64,
+    d: i64,
+    s0: String,
+    s1: String,
+    s2: String,
+    s3: String,
+}
+
+#[derive(Deserialize)]
+struct MixedBorrowed<'a> {
+    a: i64,
+    b: i64,
+    c: i64,
+    d: i64,
+    #[serde(borrow)]
+    s0: &'a str,
+    #[serde(borrow)]
+    s1: &'a str,
+    #[serde(borrow)]
+    s2: &'a str,
+    #[serde(borrow)]
+    s3: &'a str,
+}
+
+// ---------------------------------------------------------------------------
+// Row builders — column names are id + c0..c{n-1}
+// ---------------------------------------------------------------------------
+
+fn cols_row(n: usize, value_len: usize) -> RowData {
+    let val = "x".repeat(value_len);
+    let mut row = RowData::with_capacity(n + 1);
+    row.push(Arc::from("id"), ColumnValue::text("1234"));
+    for i in 0..n {
+        let name: Arc<str> = Arc::from(format!("c{i}").as_str());
+        row.push(name, ColumnValue::text(&val));
+    }
+    row
+}
+
+fn mixed_row() -> RowData {
+    RowData::from_pairs(vec![
+        ("a", ColumnValue::text("100")),
+        ("b", ColumnValue::text("200")),
+        ("c", ColumnValue::text("300")),
+        ("d", ColumnValue::text("400")),
+        ("s0", ColumnValue::text("some textual payload number zero")),
+        ("s1", ColumnValue::text("another textual payload value one")),
+        ("s2", ColumnValue::text("yet more textual content in two!!")),
+        (
+            "s3",
+            ColumnValue::text("final textual field carrying three"),
+        ),
+    ])
+}
+
+// ---------------------------------------------------------------------------
+// Benches
+// ---------------------------------------------------------------------------
+
+fn bench_narrow(c: &mut Criterion) {
+    let mut group = c.benchmark_group("narrow8");
+    for value_len in [6usize, 32, 1024] {
+        let row = cols_row(8, value_len);
+
+        group.bench_with_input(BenchmarkId::new("owned", value_len), &row, |b, row| {
+            b.iter(|| {
+                let v: Narrow8Owned = black_box(row).deserialize_into().unwrap();
+                black_box(v);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("borrowed", value_len), &row, |b, row| {
+            b.iter(|| {
+                let v: Narrow8Borrowed = black_box(row).deserialize_borrowed().unwrap();
+                black_box(v);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_wide(c: &mut Criterion) {
+    let mut group = c.benchmark_group("wide24");
+    for value_len in [6usize, 32, 1024] {
+        let row = cols_row(24, value_len);
+
+        group.bench_with_input(BenchmarkId::new("owned", value_len), &row, |b, row| {
+            b.iter(|| {
+                let v: Wide24Owned = black_box(row).deserialize_into().unwrap();
+                black_box(v);
+            });
+        });
+
+        group.bench_with_input(BenchmarkId::new("borrowed", value_len), &row, |b, row| {
+            b.iter(|| {
+                let v: Wide24Borrowed = black_box(row).deserialize_borrowed().unwrap();
+                black_box(v);
+            });
+        });
+    }
+    group.finish();
+}
+
+fn bench_mixed(c: &mut Criterion) {
+    let row = mixed_row();
+    let mut group = c.benchmark_group("mixed_int_str");
+
+    group.bench_function("owned", |b| {
+        b.iter(|| {
+            let v: MixedOwned = black_box(&row).deserialize_into().unwrap();
+            black_box(v);
+        });
+    });
+
+    group.bench_function("borrowed", |b| {
+        b.iter(|| {
+            let v: MixedBorrowed = black_box(&row).deserialize_borrowed().unwrap();
+            black_box(v);
+        });
+    });
+
+    group.finish();
+}
+
+criterion_group!(benches, bench_narrow, bench_wide, bench_mixed);
+criterion_main!(benches);

--- a/examples/arbitrary-fuzzing/Cargo.lock
+++ b/examples/arbitrary-fuzzing/Cargo.lock
@@ -347,7 +347,7 @@ dependencies = [
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/examples/basic-streaming/Cargo.lock
+++ b/examples/basic-streaming/Cargo.lock
@@ -458,7 +458,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/examples/binary-column-access/Cargo.lock
+++ b/examples/binary-column-access/Cargo.lock
@@ -345,7 +345,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/examples/pg-basebackup/Cargo.lock
+++ b/examples/pg-basebackup/Cargo.lock
@@ -422,7 +422,7 @@ dependencies = [
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/examples/polling/Cargo.lock
+++ b/examples/polling/Cargo.lock
@@ -375,7 +375,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/examples/rate-limited-streaming/Cargo.lock
+++ b/examples/rate-limited-streaming/Cargo.lock
@@ -446,7 +446,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/examples/safe-transaction-consumer/Cargo.lock
+++ b/examples/safe-transaction-consumer/Cargo.lock
@@ -369,7 +369,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/examples/tokio-spawn-streaming/Cargo.lock
+++ b/examples/tokio-spawn-streaming/Cargo.lock
@@ -369,7 +369,7 @@ checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "bytes",
  "chrono",

--- a/examples/typed-deserialization/Cargo.lock
+++ b/examples/typed-deserialization/Cargo.lock
@@ -756,7 +756,7 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/load-tests/Cargo.lock
+++ b/load-tests/Cargo.lock
@@ -915,7 +915,7 @@ dependencies = [
 
 [[package]]
 name = "pg_walstream"
-version = "0.6.3"
+version = "0.7.0"
 dependencies = [
  "aws-lc-rs",
  "bytes",

--- a/src/column_value.rs
+++ b/src/column_value.rs
@@ -445,6 +445,44 @@ impl RowData {
         T::deserialize(crate::deserializer::RowDataDeserializer::new(self))
     }
 
+    /// Zero-copy deserialize: borrow column data directly from this row.
+    ///
+    /// Unlike [`deserialize_into`](Self::deserialize_into), the target `T` may
+    /// borrow from the row (`&'de str`, `&'de [u8]`, `Cow<'de, str>`), so a
+    /// string-heavy row deserializes with zero per-field allocation. The row
+    /// (and the underlying protocol buffer it slices) must outlive `T`.
+    ///
+    /// `String`/owned fields still work — they copy, exactly as with
+    /// `deserialize_into`.
+    ///
+    /// # Caveat: borrowed bytes are raw pgoutput text
+    ///
+    /// A `&'de [u8]` / `&'de str` borrows the column's *raw* pgoutput bytes. For a `bytea` column (delivered as text like `\x00ff`) that means the escaped text, **not** the decoded binary — decode it yourself, or use an owned type with a deserializer that unescapes. This matches the existing `deserialize_into` semantics; borrowing only removes the copy.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use pg_walstream::{RowData, ColumnValue};
+    /// use serde::Deserialize;
+    ///
+    /// #[derive(Deserialize)]
+    /// struct Row<'a> {
+    ///     id: u32,
+    ///     name: &'a str,
+    /// }
+    ///
+    /// let row = RowData::from_pairs(vec![
+    ///     ("id", ColumnValue::text("42")),
+    ///     ("name", ColumnValue::text("Alice")),
+    /// ]);
+    /// let r: Row = row.deserialize_borrowed().unwrap();
+    /// assert_eq!(r.id, 42);
+    /// assert_eq!(r.name, "Alice");
+    /// ```
+    pub fn deserialize_borrowed<'de, T: Deserialize<'de>>(&'de self) -> crate::error::Result<T> {
+        T::deserialize(crate::deserializer::RowDataDeserializer::new(self))
+    }
+
     /// Lenient deserialization: returns a [`TryDeserializeResult`] whose `value`
     /// always contains a populated `T` (with per-type defaults substituted for
     /// columns that fail to parse) and whose `errors` lists every failing field.

--- a/src/connection/native/copy.rs
+++ b/src/connection/native/copy.rs
@@ -22,6 +22,13 @@ const HEADER_LEN: usize = 5;
 /// Maximum allowed message body length (128 MiB), matching wire.rs.
 const MAX_MESSAGE_LEN: usize = 128 * 1024 * 1024;
 
+/// Headroom reserved on `read_buf` before each socket read.
+///
+/// `read_buf` on a full `BytesMut` reserves only 64 bytes at a time, capping each `read()` to a tiny slice and multiplying syscalls under load. Reserving a large chunk lets one syscall pull far more TLS-decrypted data, so the drain loop slices more messages per read.
+///
+/// ponytail: 256 KiB is a common sweet spot; the win is syscall-count, which this repo has no IO benchmark to measure — tune here if a real workload shows read/syscall dominating a flamegraph.
+const READ_CHUNK: usize = 256 * 1024;
+
 /// Read the next CopyData payload from the replication stream.
 ///
 /// This implements a **drain-loop batch queue** optimization:
@@ -47,7 +54,10 @@ pub async fn get_copy_data<R: AsyncRead + Unpin>(
             return Ok(payload);
         }
 
-        // ── Slow path: read from transport, drain all complete messages ──
+        // Ensure a large contiguous headroom BEFORE the read so one read() pulls as much as possible. `pending` is empty here (fast path returned above) and the buffer is typically drained, so this reserve is cheap — no realloc of live data. See READ_CHUNK.
+        if read_buf.capacity() - read_buf.len() < READ_CHUNK {
+            read_buf.reserve(READ_CHUNK);
+        }
         tokio::select! {
             biased;
             _ = cancellation_token.cancelled() => {

--- a/src/connection/native/copy.rs
+++ b/src/connection/native/copy.rs
@@ -26,8 +26,15 @@ const MAX_MESSAGE_LEN: usize = 128 * 1024 * 1024;
 ///
 /// `read_buf` on a full `BytesMut` reserves only 64 bytes at a time, capping each `read()` to a tiny slice and multiplying syscalls under load. Reserving a large chunk lets one syscall pull far more TLS-decrypted data, so the drain loop slices more messages per read.
 ///
-/// ponytail: 256 KiB is a common sweet spot; the win is syscall-count, which this repo has no IO benchmark to measure — tune here if a real workload shows read/syscall dominating a flamegraph.
+/// Note: 256 KiB is a common sweet spot; the win is syscall-count, which this repo has no IO benchmark to measure — tune here if a real workload shows read/syscall dominating a flamegraph.
 const READ_CHUNK: usize = 256 * 1024;
+
+/// Minimum free headroom that triggers a `reserve(READ_CHUNK)` top-up.
+///
+/// Using `READ_CHUNK` itself as the threshold would realloc on almost every
+/// read: after each drain, frozen slices pin the buffer so `reserve` can't
+/// reclaim, and the remaining headroom sits just below `READ_CHUNK` → reserve fires and reallocs every iteration. Checking against this smaller threshold lets one 256 KiB reservation serve many reads before the next top-up.
+const MIN_HEADROOM: usize = 64 * 1024;
 
 /// Read the next CopyData payload from the replication stream.
 ///
@@ -54,8 +61,8 @@ pub async fn get_copy_data<R: AsyncRead + Unpin>(
             return Ok(payload);
         }
 
-        // Ensure a large contiguous headroom BEFORE the read so one read() pulls as much as possible. `pending` is empty here (fast path returned above) and the buffer is typically drained, so this reserve is cheap — no realloc of live data. See READ_CHUNK.
-        if read_buf.capacity() - read_buf.len() < READ_CHUNK {
+        // Ensure a large contiguous headroom BEFORE the read so one read() pulls as much as possible. Reserve only when free headroom drops below MIN_HEADROOM (not READ_CHUNK), so one 256 KiB reservation serves many reads instead of reallocating every iteration. `pending` is empty here (fast path returned above).
+        if read_buf.capacity() - read_buf.len() < MIN_HEADROOM {
             read_buf.reserve(READ_CHUNK);
         }
         tokio::select! {
@@ -545,6 +552,88 @@ mod tests {
         assert!(result.is_err());
         let err = result.unwrap_err();
         assert!(matches!(err, ReplicationError::Cancelled(_)));
+    }
+
+    #[tokio::test]
+    async fn test_get_copy_data_cancelled_with_buffered_data() {
+        // Cancelled, but a complete message is already sitting in read_buf → it
+        // must be drained and returned rather than dropped.
+        let (mut client, _server) = tokio::io::duplex(8192);
+        let token = CancellationToken::new();
+        token.cancel();
+
+        let payload = b"buffered";
+        let body_len = (4 + payload.len()) as i32;
+        let mut read_buf = BytesMut::new();
+        read_buf.extend_from_slice(b"d");
+        read_buf.extend_from_slice(&body_len.to_be_bytes());
+        read_buf.extend_from_slice(payload);
+
+        let mut pending = VecDeque::new();
+        let result = get_copy_data(&mut client, &mut read_buf, &mut pending, &token).await;
+        assert_eq!(&result.unwrap()[..], b"buffered");
+    }
+
+    #[tokio::test]
+    async fn test_get_copy_data_connection_closed() {
+        // Server hangs up → read returns 0 → transient "connection closed" error.
+        let (mut client, server) = tokio::io::duplex(8192);
+        drop(server);
+        let token = CancellationToken::new();
+        let mut read_buf = BytesMut::new();
+        let mut pending = VecDeque::new();
+        let result = get_copy_data(&mut client, &mut read_buf, &mut pending, &token).await;
+        let err = result.unwrap_err();
+        assert!(
+            format!("{err}").contains("closed"),
+            "expected connection-closed error, got: {err}"
+        );
+    }
+
+    #[tokio::test]
+    async fn test_get_copy_data_server_error_response() {
+        // An ErrorResponse ('E') during COPY surfaces as a protocol error.
+        use tokio::io::AsyncWriteExt;
+        let (mut client, mut server) = tokio::io::duplex(8192);
+        let token = CancellationToken::new();
+        tokio::spawn(async move {
+            let fields = b"SERROR\0C28000\0Mnope\0\0";
+            let body_len = (4 + fields.len()) as i32;
+            let mut msg = vec![b'E'];
+            msg.extend_from_slice(&body_len.to_be_bytes());
+            msg.extend_from_slice(fields);
+            server.write_all(&msg).await.unwrap();
+            server.flush().await.unwrap();
+        });
+        let mut read_buf = BytesMut::new();
+        let mut pending = VecDeque::new();
+        let result = get_copy_data(&mut client, &mut read_buf, &mut pending, &token).await;
+        assert!(result.is_err(), "server ErrorResponse should error");
+    }
+
+    #[tokio::test]
+    async fn test_get_copy_data_partial_then_complete() {
+        // First read delivers only part of a message → the loop must `continue`
+        // and read again before returning the assembled payload.
+        use tokio::io::AsyncWriteExt;
+        let (mut client, mut server) = tokio::io::duplex(8192);
+        let token = CancellationToken::new();
+        tokio::spawn(async move {
+            let payload = b"split payload";
+            let body_len = (4 + payload.len()) as i32;
+            let mut msg = vec![b'd'];
+            msg.extend_from_slice(&body_len.to_be_bytes());
+            msg.extend_from_slice(payload);
+            server.write_all(&msg[..7]).await.unwrap();
+            server.flush().await.unwrap();
+            tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+            server.write_all(&msg[7..]).await.unwrap();
+            server.flush().await.unwrap();
+        });
+        let mut read_buf = BytesMut::new();
+        let mut pending = VecDeque::new();
+        let result = get_copy_data(&mut client, &mut read_buf, &mut pending, &token).await;
+        assert_eq!(&result.unwrap()[..], b"split payload");
     }
 
     #[tokio::test]

--- a/src/connection/native/error.rs
+++ b/src/connection/native/error.rs
@@ -67,36 +67,31 @@ pub fn parse_error_fields(payload: &[u8]) -> PgErrorFields {
     fields
 }
 
-/// Parse an ErrorResponse message (including the 5-byte header) into
-/// a `ReplicationError`.
-#[allow(dead_code)]
-pub fn error_response_to_replication_error(msg: &[u8]) -> crate::error::ReplicationError {
-    let fields = parse_error_fields(&msg[5..]); // skip tag + length
-    let error_lower = fields.message.to_lowercase();
-
-    if error_lower.contains("authentication")
-        || error_lower.contains("password")
-        || fields.code.starts_with("28")
-    // Class 28 — Invalid Authorization
-    {
-        crate::error::ReplicationError::authentication(format!(
-            "PostgreSQL authentication failed: {}",
-            fields
-        ))
-    } else if fields.severity == "FATAL" || fields.severity == "PANIC" {
-        crate::error::ReplicationError::permanent_connection(format!(
-            "PostgreSQL fatal error: {}",
-            fields
-        ))
-    } else {
-        crate::error::ReplicationError::protocol(format!("PostgreSQL error: {}", fields))
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
+    fn error_response_to_replication_error(msg: &[u8]) -> crate::error::ReplicationError {
+        let fields = parse_error_fields(&msg[5..]); // skip tag + length
+        let error_lower = fields.message.to_lowercase();
+
+        if error_lower.contains("authentication")
+            || error_lower.contains("password")
+            || fields.code.starts_with("28")
+        {
+            crate::error::ReplicationError::authentication(format!(
+                "PostgreSQL authentication failed: {}",
+                fields
+            ))
+        } else if fields.severity == "FATAL" || fields.severity == "PANIC" {
+            crate::error::ReplicationError::permanent_connection(format!(
+                "PostgreSQL fatal error: {}",
+                fields
+            ))
+        } else {
+            crate::error::ReplicationError::protocol(format!("PostgreSQL error: {}", fields))
+        }
+    }
     #[test]
     fn test_parse_error_fields() {
         let mut payload = Vec::new();

--- a/src/connection/native/startup.rs
+++ b/src/connection/native/startup.rs
@@ -350,6 +350,7 @@ async fn negotiate_tls_standard(
             })?;
 
             tracing::debug!("TLS connection established");
+            log_negotiated_suite(&tls_stream);
             Ok(Transport::Tls(BufReader::with_capacity(
                 TLS_BUF_SIZE,
                 tls_stream,
@@ -405,10 +406,19 @@ async fn negotiate_tls_direct(
     })?;
 
     tracing::debug!("Direct TLS connection established (ALPN postgresql)");
+    log_negotiated_suite(&tls_stream);
     Ok(Transport::Tls(BufReader::with_capacity(
         TLS_BUF_SIZE,
         tls_stream,
     )))
+}
+
+/// Log the negotiated TLS cipher suite for verification that hardware-accelerated
+/// AES-GCM (via aws-lc-rs) was selected rather than an unexpected fallback.
+fn log_negotiated_suite(tls_stream: &tokio_rustls::client::TlsStream<TcpStream>) {
+    if let Some(suite) = tls_stream.get_ref().1.negotiated_cipher_suite() {
+        tracing::info!("TLS negotiated cipher suite: {:?}", suite.suite());
+    }
 }
 
 /// Build a rustls `ClientConfig` based on the sslmode.

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -148,7 +148,8 @@ impl<'a> RowDataDeserializer<'a> {
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for RowDataDeserializer<'a> {
+// The data lifetime IS serde's `'de`: values borrow directly from `&'de RowData`, `deserialize_into<DeserializeOwned>` still compiles because `for<'de>` covers the concrete borrow lifetime; `deserialize_borrowed<'de>` exposes the borrow.
+impl<'de> de::Deserializer<'de> for RowDataDeserializer<'de> {
     type Error = ReplicationError;
 
     #[inline]
@@ -193,7 +194,7 @@ struct RowDataMapAccess<'a> {
     current_value: Option<&'a ColumnValue>,
 }
 
-impl<'de, 'a> MapAccess<'de> for RowDataMapAccess<'a> {
+impl<'de> MapAccess<'de> for RowDataMapAccess<'de> {
     type Error = ReplicationError;
 
     #[inline]
@@ -238,10 +239,10 @@ struct ColumnValueDeserializer<'a> {
     value: &'a ColumnValue,
 }
 
-impl<'a> ColumnValueDeserializer<'a> {
+impl<'de> ColumnValueDeserializer<'de> {
     /// Get the text content or return an error for the given target type.
     #[inline]
-    fn text_or_err(&self, target: &str) -> Result<&'a str, ReplicationError> {
+    fn text_or_err(&self, target: &str) -> Result<&'de str, ReplicationError> {
         match self.value {
             ColumnValue::Text(b) => core::str::from_utf8(b).map_err(|e| {
                 ReplicationError::deserialize(format!("invalid UTF-8 for {target}: {e}"))
@@ -259,7 +260,7 @@ impl<'a> ColumnValueDeserializer<'a> {
     /// Use only for paths where the parser itself rejects non-ASCII bytes
     /// (numeric, bool). String-shaped paths must use `text_or_err`.
     #[inline]
-    fn bytes_or_err(&self, target: &str) -> Result<&'a [u8], ReplicationError> {
+    fn bytes_or_err(&self, target: &str) -> Result<&'de [u8], ReplicationError> {
         match self.value {
             ColumnValue::Text(b) => Ok(b.as_ref()),
             ColumnValue::Null => Err(ReplicationError::deserialize(format!(
@@ -319,7 +320,7 @@ fn numeric_parse_error(b: &[u8], type_name: &str) -> ReplicationError {
     }
 }
 
-impl<'de, 'a> de::Deserializer<'de> for ColumnValueDeserializer<'a> {
+impl<'de> de::Deserializer<'de> for ColumnValueDeserializer<'de> {
     type Error = ReplicationError;
 
     #[inline]
@@ -327,10 +328,10 @@ impl<'de, 'a> de::Deserializer<'de> for ColumnValueDeserializer<'a> {
         match self.value {
             ColumnValue::Null => visitor.visit_none(),
             ColumnValue::Text(b) => match core::str::from_utf8(b) {
-                Ok(s) => visitor.visit_str(s),
-                Err(_) => visitor.visit_bytes(b),
+                Ok(s) => visitor.visit_borrowed_str(s),
+                Err(_) => visitor.visit_borrowed_bytes(b),
             },
-            ColumnValue::Binary(b) => visitor.visit_bytes(b),
+            ColumnValue::Binary(b) => visitor.visit_borrowed_bytes(b),
         }
     }
 
@@ -411,19 +412,19 @@ impl<'de, 'a> de::Deserializer<'de> for ColumnValueDeserializer<'a> {
     #[inline]
     fn deserialize_str<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         let s = self.text_or_err("str")?;
-        visitor.visit_str(s)
+        visitor.visit_borrowed_str(s)
     }
 
     #[inline]
     fn deserialize_string<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         let s = self.text_or_err("String")?;
-        visitor.visit_str(s)
+        visitor.visit_borrowed_str(s)
     }
 
     #[inline]
     fn deserialize_bytes<V: Visitor<'de>>(self, visitor: V) -> Result<V::Value, Self::Error> {
         match self.value {
-            ColumnValue::Binary(b) | ColumnValue::Text(b) => visitor.visit_bytes(b),
+            ColumnValue::Binary(b) | ColumnValue::Text(b) => visitor.visit_borrowed_bytes(b),
             ColumnValue::Null => Err(ReplicationError::deserialize(
                 "cannot deserialize NULL as bytes",
             )),
@@ -1002,6 +1003,8 @@ pub(crate) fn try_deserialize_row<T: serde::de::DeserializeOwned>(
 
 #[cfg(test)]
 mod tests {
+    #![allow(dead_code)]
+
     use crate::column_value::{ColumnValue, RowData};
     use crate::types::{ChangeEvent, Lsn, ReplicaIdentity};
     use bytes::Bytes;
@@ -1106,7 +1109,6 @@ mod tests {
         let row = RowData::from_pairs(vec![("a", ColumnValue::text("maybe"))]);
         #[derive(Debug, Deserialize)]
         struct B {
-            #[allow(dead_code)]
             a: bool,
         }
         let result: crate::error::Result<B> = row.deserialize_into();
@@ -1182,7 +1184,6 @@ mod tests {
         let row = RowData::from_pairs(vec![("id", ColumnValue::Null)]);
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             id: u32,
         }
         let result: crate::error::Result<S> = row.deserialize_into();
@@ -1196,7 +1197,6 @@ mod tests {
         let row = RowData::from_pairs(vec![("id", ColumnValue::text("not_a_number"))]);
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             id: u32,
         }
         let result: crate::error::Result<S> = row.deserialize_into();
@@ -1210,7 +1210,6 @@ mod tests {
         let row = RowData::from_pairs(vec![("val", ColumnValue::text("99999"))]);
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             val: i8,
         }
         let result: crate::error::Result<S> = row.deserialize_into();
@@ -1291,7 +1290,6 @@ mod tests {
     fn test_char_too_long() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             c: char,
         }
         let row = RowData::from_pairs(vec![("c", ColumnValue::text("AB"))]);
@@ -1585,7 +1583,6 @@ mod tests {
         #[derive(Debug, Deserialize)]
         struct S {
             #[serde(with = "serde_bytes")]
-            #[allow(dead_code)]
             data: Vec<u8>,
         }
         let row = RowData::from_pairs(vec![("data", ColumnValue::Null)]);
@@ -1643,7 +1640,6 @@ mod tests {
     fn test_unit_from_non_null_errors() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             val: (),
         }
         let row = RowData::from_pairs(vec![("val", ColumnValue::text("something"))]);
@@ -1659,7 +1655,6 @@ mod tests {
     fn test_seq_not_supported() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             vals: Vec<u32>,
         }
         let row = RowData::from_pairs(vec![("vals", ColumnValue::text("[1,2,3]"))]);
@@ -1673,12 +1668,10 @@ mod tests {
     fn test_nested_struct_not_supported() {
         #[derive(Debug, Deserialize)]
         struct Inner {
-            #[allow(dead_code)]
             x: u32,
         }
         #[derive(Debug, Deserialize)]
         struct Outer {
-            #[allow(dead_code)]
             inner: Inner,
         }
         let row = RowData::from_pairs(vec![("inner", ColumnValue::text("{\"x\":1}"))]);
@@ -1694,7 +1687,6 @@ mod tests {
     fn test_null_bool_errors() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             flag: bool,
         }
         let row = RowData::from_pairs(vec![("flag", ColumnValue::Null)]);
@@ -1708,7 +1700,6 @@ mod tests {
     fn test_binary_numeric_errors() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             val: i32,
         }
         let row = RowData::from_pairs(vec![(
@@ -1725,7 +1716,6 @@ mod tests {
     fn test_binary_bool_errors() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             flag: bool,
         }
         let row = RowData::from_pairs(vec![(
@@ -1746,7 +1736,6 @@ mod tests {
         )]);
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             username: String,
         }
         let result: crate::error::Result<S> = row.deserialize_into();
@@ -1760,7 +1749,6 @@ mod tests {
         let row = RowData::from_pairs(vec![("name", ColumnValue::Null)]);
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             name: String,
         }
         let result: crate::error::Result<S> = row.deserialize_into();
@@ -1775,7 +1763,6 @@ mod tests {
     fn test_char_empty_string_errors() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             c: char,
         }
         let row = RowData::from_pairs(vec![("c", ColumnValue::text(""))]);
@@ -1787,7 +1774,6 @@ mod tests {
     fn test_char_null_errors() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             c: char,
         }
         let row = RowData::from_pairs(vec![("c", ColumnValue::Null)]);
@@ -1984,7 +1970,6 @@ mod tests {
         #[derive(Debug, Deserialize)]
         struct S {
             #[serde(with = "serde_bytes")]
-            #[allow(dead_code)]
             data: Vec<u8>,
         }
         let row = RowData::from_pairs(vec![("data", ColumnValue::Null)]);
@@ -1998,7 +1983,6 @@ mod tests {
     fn test_tuple_not_supported() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             pair: (u32, u32),
         }
         let row = RowData::from_pairs(vec![("pair", ColumnValue::text("1,2"))]);
@@ -2011,10 +1995,9 @@ mod tests {
     #[test]
     fn test_tuple_struct_not_supported() {
         #[derive(Debug, Deserialize)]
-        struct Pair(#[allow(dead_code)] u32, #[allow(dead_code)] u32);
+        struct Pair(u32, u32);
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             p: Pair,
         }
         let row = RowData::from_pairs(vec![("p", ColumnValue::text("1,2"))]);
@@ -2029,7 +2012,6 @@ mod tests {
         use std::collections::HashMap;
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             m: HashMap<String, String>,
         }
         let row = RowData::from_pairs(vec![("m", ColumnValue::text("{}"))]);
@@ -2084,7 +2066,6 @@ mod tests {
     fn test_boolean_invalid_single_char() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             a: bool,
         }
         let row = RowData::from_pairs(vec![("a", ColumnValue::text("x"))]);
@@ -2149,7 +2130,6 @@ mod tests {
         )]);
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             val: u32,
         }
         let result: crate::error::Result<S> = row.deserialize_into();
@@ -2205,12 +2185,10 @@ mod tests {
     fn test_enum_newtype_variant_not_supported() {
         #[derive(Debug, Deserialize)]
         enum E {
-            #[allow(dead_code)]
             V(u32),
         }
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             e: E,
         }
         let row = RowData::from_pairs(vec![("e", ColumnValue::text("V"))]);
@@ -2224,12 +2202,10 @@ mod tests {
     fn test_enum_tuple_variant_not_supported() {
         #[derive(Debug, Deserialize)]
         enum E {
-            #[allow(dead_code)]
             V(u32, u32),
         }
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             e: E,
         }
         let row = RowData::from_pairs(vec![("e", ColumnValue::text("V"))]);
@@ -2243,12 +2219,10 @@ mod tests {
     fn test_enum_struct_variant_not_supported() {
         #[derive(Debug, Deserialize)]
         enum E {
-            #[allow(dead_code)]
             V { x: u32 },
         }
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             e: E,
         }
         let row = RowData::from_pairs(vec![("e", ColumnValue::text("V"))]);
@@ -2509,7 +2483,6 @@ mod tests {
     #[test]
     fn test_try_into_result_err() {
         #[derive(Debug, Deserialize)]
-        #[allow(dead_code)]
         struct S {
             id: u32,
         }
@@ -2524,7 +2497,6 @@ mod tests {
     fn test_try_unit_on_non_null_reports_but_succeeds() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             marker: (),
         }
         let row = RowData::from_pairs(vec![("marker", ColumnValue::text("x"))]);
@@ -2568,12 +2540,10 @@ mod tests {
     fn test_try_nested_struct_errors_structural() {
         #[derive(Debug, Deserialize)]
         struct Inner {
-            #[allow(dead_code)]
             x: u32,
         }
         #[derive(Debug, Deserialize)]
         struct Outer {
-            #[allow(dead_code)]
             inner: Inner,
         }
         let row = RowData::from_pairs(vec![("inner", ColumnValue::text("{}"))]);
@@ -2596,7 +2566,6 @@ mod tests {
     #[test]
     fn test_try_is_clean_false_when_errors_recorded() {
         #[derive(Debug, Deserialize)]
-        #[allow(dead_code)]
         struct S {
             v: u32,
         }
@@ -2645,11 +2614,9 @@ mod tests {
     #[test]
     fn test_try_lenient_tuple_struct_errors() {
         #[derive(Debug, Deserialize)]
-        #[allow(dead_code)]
         struct TS(u32, u32);
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             t: TS,
         }
         let row = RowData::from_pairs(vec![("t", ColumnValue::text("1,2"))]);
@@ -2661,7 +2628,6 @@ mod tests {
     fn test_try_lenient_seq_errors() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             xs: Vec<u32>,
         }
         let row = RowData::from_pairs(vec![("xs", ColumnValue::text("1"))]);
@@ -2674,7 +2640,6 @@ mod tests {
         use std::collections::HashMap;
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             m: HashMap<String, String>,
         }
         let row = RowData::from_pairs(vec![("m", ColumnValue::text("{}"))]);
@@ -2730,7 +2695,6 @@ mod tests {
         struct Marker;
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             m: Marker,
         }
         let row = RowData::from_pairs(vec![("m", ColumnValue::Null)]);
@@ -2783,13 +2747,11 @@ mod tests {
     fn test_strict_unit_variant_newtype_errors() {
         // Exercise UnitVariantAccess::newtype_variant_seed error path.
         #[derive(Debug, Deserialize)]
-        #[allow(dead_code)]
         enum E {
             A(u32),
         }
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             e: E,
         }
         let row = RowData::from_pairs(vec![("e", ColumnValue::text("A"))]);
@@ -3164,7 +3126,6 @@ mod tests {
         struct Marker;
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             m: Marker,
         }
         let row = RowData::from_pairs(vec![("m", ColumnValue::text("x"))]);
@@ -3413,7 +3374,6 @@ mod tests {
     fn test_strict_float_parse_error() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             v: f64,
         }
         let row = RowData::from_pairs(vec![("v", ColumnValue::text("not_float"))]);
@@ -3429,7 +3389,6 @@ mod tests {
     fn test_strict_binary_char_errors() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             c: char,
         }
         let row = RowData::from_pairs(vec![(
@@ -3446,7 +3405,6 @@ mod tests {
     fn test_strict_null_char_errors() {
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             c: char,
         }
         let row = RowData::from_pairs(vec![("c", ColumnValue::Null)]);
@@ -3569,12 +3527,10 @@ mod tests {
     fn test_try_lenient_enum_binary_structural_error() {
         #[derive(Debug, Deserialize)]
         enum E {
-            #[allow(dead_code)]
             A,
         }
         #[derive(Debug, Deserialize)]
         struct S {
-            #[allow(dead_code)]
             e: E,
         }
         let row = RowData::from_pairs(vec![(
@@ -3592,7 +3548,6 @@ mod tests {
         #[derive(Debug, Deserialize)]
         #[serde(deny_unknown_fields)]
         struct Strict {
-            #[allow(dead_code)]
             id: u32,
         }
         let row = RowData::from_pairs(vec![
@@ -3623,5 +3578,123 @@ mod tests {
         assert_eq!(v.id, 42);
         assert_eq!(v.score, 0.0);
         assert_eq!(v.name, None);
+    }
+
+    // -- Borrowed (zero-copy) deserialization --------------------------------
+
+    #[test]
+    fn test_deserialize_borrowed_str() {
+        // &'de str borrows straight from the row's Bytes — no allocation.
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Row<'a> {
+            id: u32,
+            name: &'a str,
+        }
+        let row = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("42")),
+            ("name", ColumnValue::text("alice")),
+        ]);
+        let r: Row = row.deserialize_borrowed().unwrap();
+        assert_eq!(r.id, 42);
+        assert_eq!(r.name, "alice");
+        // Prove it actually points into the row's buffer, not a copy.
+        let backing = row.get("name").unwrap().as_bytes().as_ptr();
+        assert_eq!(r.name.as_ptr(), backing);
+    }
+
+    #[test]
+    fn test_deserialize_borrowed_bytes() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Row<'a> {
+            #[serde(with = "serde_bytes")]
+            payload: &'a [u8],
+        }
+        let row = RowData::from_pairs(vec![(
+            "payload",
+            ColumnValue::binary_bytes(Bytes::from_static(&[0xde, 0xad, 0xbe, 0xef])),
+        )]);
+        let r: Row = row.deserialize_borrowed().unwrap();
+        assert_eq!(r.payload, &[0xde, 0xad, 0xbe, 0xef]);
+        let backing = row.get("payload").unwrap().as_bytes().as_ptr();
+        assert_eq!(r.payload.as_ptr(), backing);
+    }
+
+    #[test]
+    fn test_deserialize_borrowed_cow_clean_borrows() {
+        // Clean data → Cow::Borrowed, no allocation.
+        use std::borrow::Cow;
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Row<'a> {
+            #[serde(borrow)]
+            note: Cow<'a, str>,
+        }
+        let row = RowData::from_pairs(vec![("note", ColumnValue::text("clean"))]);
+        let r: Row = row.deserialize_borrowed().unwrap();
+        assert!(matches!(r.note, Cow::Borrowed(_)), "expected borrowed");
+        assert_eq!(r.note, "clean");
+    }
+
+    #[test]
+    fn test_deserialize_borrowed_option_some_and_null() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Row<'a> {
+            #[serde(borrow)]
+            a: Option<&'a str>,
+            #[serde(borrow)]
+            b: Option<&'a str>,
+        }
+        let row = RowData::from_pairs(vec![
+            ("a", ColumnValue::text("here")),
+            ("b", ColumnValue::Null),
+        ]);
+        let r: Row = row.deserialize_borrowed().unwrap();
+        assert_eq!(r.a, Some("here"));
+        assert_eq!(r.b, None);
+    }
+
+    #[test]
+    fn test_deserialize_borrowed_owned_string_still_works() {
+        // Owned String field via the borrowing entry point: copies, as expected.
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Row {
+            name: String,
+        }
+        let row = RowData::from_pairs(vec![("name", ColumnValue::text("owned"))]);
+        let r: Row = row.deserialize_borrowed().unwrap();
+        assert_eq!(r.name, "owned");
+    }
+
+    #[test]
+    fn test_deserialize_borrowed_via_change_event() {
+        use crate::types::{ChangeEvent, Lsn};
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Row<'a> {
+            id: u32,
+            name: &'a str,
+        }
+        let data = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("7")),
+            ("name", ColumnValue::text("zed")),
+        ]);
+        let event = ChangeEvent::insert("public", "users", 1, data, Lsn::new(1));
+        let r: Row = event.deserialize_data_borrowed().unwrap();
+        assert_eq!(r.id, 7);
+        assert_eq!(r.name, "zed");
+    }
+
+    #[test]
+    fn test_deserialize_borrowed_invalid_utf8_text_as_bytes() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Row<'a> {
+            #[serde(with = "serde_bytes")]
+            raw: &'a [u8],
+        }
+        let bad = Bytes::from_static(&[0xff, 0xfe, 0x00, 0xfd]);
+        let row = RowData::from_pairs(vec![("raw", ColumnValue::text_bytes(bad))]);
+        let r: Row = row.deserialize_borrowed().unwrap();
+        assert_eq!(r.raw, &[0xff, 0xfe, 0x00, 0xfd]);
+        // Borrowed straight from the column buffer, not copied.
+        let backing = row.get("raw").unwrap().as_bytes().as_ptr();
+        assert_eq!(r.raw.as_ptr(), backing);
     }
 }

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -205,7 +205,8 @@ impl<'de> MapAccess<'de> for RowDataMapAccess<'de> {
         match self.iter.next() {
             Some((key, value)) => {
                 self.current_value = Some(value);
-                let key_de = serde::de::value::StrDeserializer::new(key.as_ref());
+                // Struct fields already match names without allocating.
+                let key_de = serde::de::value::BorrowedStrDeserializer::new(key.as_ref());
                 seed.deserialize(key_de).map(Some)
             }
             None => Ok(None),
@@ -3696,5 +3697,104 @@ mod tests {
         // Borrowed straight from the column buffer, not copied.
         let backing = row.get("raw").unwrap().as_bytes().as_ptr();
         assert_eq!(r.raw.as_ptr(), backing);
+    }
+
+    #[test]
+    fn test_deserialize_borrowed_map_keys_are_borrowed() {
+        // A HashMap<&'de str, &'de str> borrows BOTH keys and values straight
+        // from the row — the map key aliases the column's Arc<str> name buffer.
+        use std::collections::HashMap;
+        let row = RowData::from_pairs(vec![
+            ("alpha", ColumnValue::text("one")),
+            ("beta", ColumnValue::text("two")),
+        ]);
+        let m: HashMap<&str, &str> = row.deserialize_borrowed().unwrap();
+        assert_eq!(m.get("alpha"), Some(&"one"));
+        assert_eq!(m.get("beta"), Some(&"two"));
+
+        // Prove the key is borrowed, not copied: its pointer must equal the
+        // Arc<str> name backing the corresponding column.
+        let (name_arc, _) = row
+            .iter()
+            .find(|(k, _)| k.as_ref() == "alpha")
+            .expect("column present");
+        let borrowed_key: &&str = m.keys().find(|k| ***k == *"alpha").expect("key present");
+        let name_ptr = name_arc.as_bytes().as_ptr();
+        let key_ptr = borrowed_key.as_bytes().as_ptr();
+        assert_eq!(key_ptr, name_ptr);
+    }
+
+    #[test]
+    fn test_column_value_deserialize_any_borrowed_branches() {
+        // Directly exercise ColumnValueDeserializer::deserialize_any for all four
+        // variants — the borrowed-str / borrowed-bytes / none arms. Reached by
+        // self-describing targets (serde_json::Value, IgnoredAny, flatten).
+        use serde::de::{Deserializer as _, Visitor};
+        use std::fmt;
+
+        #[derive(Debug, PartialEq)]
+        enum Got {
+            Str(String),
+            Bytes(Vec<u8>),
+            None,
+        }
+        struct Rec;
+        impl<'de> Visitor<'de> for Rec {
+            type Value = Got;
+            fn expecting(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                write!(f, "anything")
+            }
+            fn visit_borrowed_str<E>(self, v: &'de str) -> Result<Got, E> {
+                Ok(Got::Str(v.to_string()))
+            }
+            fn visit_str<E>(self, v: &str) -> Result<Got, E> {
+                Ok(Got::Str(v.to_string()))
+            }
+            fn visit_borrowed_bytes<E>(self, v: &'de [u8]) -> Result<Got, E> {
+                Ok(Got::Bytes(v.to_vec()))
+            }
+            fn visit_bytes<E>(self, v: &[u8]) -> Result<Got, E> {
+                Ok(Got::Bytes(v.to_vec()))
+            }
+            fn visit_none<E>(self) -> Result<Got, E> {
+                Ok(Got::None)
+            }
+        }
+
+        // Text (valid UTF-8) → visit_borrowed_str
+        let cv = ColumnValue::text("hello");
+        let d = super::ColumnValueDeserializer { value: &cv };
+        assert_eq!(d.deserialize_any(Rec).unwrap(), Got::Str("hello".into()));
+
+        // Text (invalid UTF-8) → visit_borrowed_bytes
+        let cv = ColumnValue::text_bytes(Bytes::from_static(&[0xff, 0xfe]));
+        let d = super::ColumnValueDeserializer { value: &cv };
+        assert_eq!(
+            d.deserialize_any(Rec).unwrap(),
+            Got::Bytes(vec![0xff, 0xfe])
+        );
+
+        // Binary → visit_borrowed_bytes
+        let cv = ColumnValue::binary_bytes(Bytes::from_static(&[1, 2, 3]));
+        let d = super::ColumnValueDeserializer { value: &cv };
+        assert_eq!(d.deserialize_any(Rec).unwrap(), Got::Bytes(vec![1, 2, 3]));
+
+        // Null → visit_none
+        let cv = ColumnValue::Null;
+        let d = super::ColumnValueDeserializer { value: &cv };
+        assert_eq!(d.deserialize_any(Rec).unwrap(), Got::None);
+    }
+
+    #[test]
+    fn test_deserialize_borrowed_null_as_bytes_errors() {
+        // NULL through the borrowed deserialize_bytes path must error, not panic.
+        #[derive(Debug, Deserialize)]
+        struct Row<'a> {
+            #[serde(with = "serde_bytes")]
+            data: &'a [u8],
+        }
+        let row = RowData::from_pairs(vec![("data", ColumnValue::Null)]);
+        let r: crate::error::Result<Row> = row.deserialize_borrowed();
+        assert!(r.is_err(), "NULL as borrowed bytes should error");
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -2076,10 +2076,6 @@ mod tests {
     use crate::protocol::TupleData;
     use crate::types::{parse_lsn, ReplicaIdentity};
 
-    // ========================================
-    // Compile-time Send/Sync assertions
-    // ========================================
-    // These ensure that key types can be used inside tokio::spawn.
     #[allow(dead_code)]
     const _: () = {
         fn assert_send<T: Send>() {}
@@ -6742,11 +6738,6 @@ mod tests {
         assert_eq!(stream.current_lsn(), high_lsn);
     }
 
-    // ========================================
-    // futures::Stream trait tests
-    // ========================================
-
-    /// Compile-time assertion that EventStream implements key traits
     #[allow(dead_code)]
     const _: () = {
         fn assert_stream<T: futures_core::Stream>() {}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1241,6 +1241,10 @@ impl ChangeEvent {
 
     /// Zero-copy variant of [`deserialize_data`](Self::deserialize_data): the
     /// target `T` may borrow (`&'de str`, `Cow<'de, str>`, `&'de [u8]`) directly from the event's row data, so a string-heavy row costs no per-field allocation. The event must outlive `T`.
+    ///
+    /// Borrowed values alias the underlying protocol buffer and are raw pgoutput
+    /// text (see [`RowData::deserialize_borrowed`](RowData::deserialize_borrowed)
+    /// for the escaping caveat).
     pub fn deserialize_data_borrowed<'de, T: serde::Deserialize<'de>>(&'de self) -> Result<T> {
         match &self.event_type {
             EventType::Insert { data, .. } => data.deserialize_borrowed(),
@@ -3950,5 +3954,77 @@ mod tests {
             let event = ChangeEvent::relation(1, "s", "t", ri, cols, Lsn::new(50000));
             assert_encode_decode_round_trip(&event);
         }
+    }
+
+    // ---- deserialize_data_borrowed across event types ----
+
+    #[test]
+    fn test_deserialize_data_borrowed_update_and_delete() {
+        #[derive(Debug, Deserialize, PartialEq)]
+        struct Row<'a> {
+            id: u32,
+            name: &'a str,
+        }
+
+        // Update → borrows from new_data.
+        let new_data = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("9")),
+            ("name", ColumnValue::text("updated")),
+        ]);
+        let upd = ChangeEvent::update(
+            "public",
+            "users",
+            1,
+            None,
+            new_data,
+            ReplicaIdentity::Default,
+            vec![Arc::from("id")],
+            Lsn::new(1),
+        );
+        let r: Row = upd.deserialize_data_borrowed().unwrap();
+        assert_eq!(
+            r,
+            Row {
+                id: 9,
+                name: "updated"
+            }
+        );
+
+        // Delete → borrows from old_data.
+        let old_data = RowData::from_pairs(vec![
+            ("id", ColumnValue::text("3")),
+            ("name", ColumnValue::text("gone")),
+        ]);
+        let del = ChangeEvent::delete(
+            "public",
+            "users",
+            1,
+            old_data,
+            ReplicaIdentity::Full,
+            vec![Arc::from("id")],
+            Lsn::new(2),
+        );
+        let r: Row = del.deserialize_data_borrowed().unwrap();
+        assert_eq!(
+            r,
+            Row {
+                id: 3,
+                name: "gone"
+            }
+        );
+    }
+
+    #[test]
+    fn test_deserialize_data_borrowed_non_dml_errors() {
+        #[derive(Debug, Deserialize)]
+        struct Row<'a> {
+            #[allow(dead_code)]
+            name: &'a str,
+        }
+        // Begin carries no row data → error, not panic.
+        let ts = Utc.with_ymd_and_hms(2024, 7, 1, 12, 0, 0).unwrap();
+        let begin = ChangeEvent::begin(7, Lsn::new(10), ts, Lsn::new(11));
+        let r: Result<Row> = begin.deserialize_data_borrowed();
+        assert!(r.is_err(), "Begin has no row data");
     }
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1239,6 +1239,20 @@ impl ChangeEvent {
         }
     }
 
+    /// Zero-copy variant of [`deserialize_data`](Self::deserialize_data): the
+    /// target `T` may borrow (`&'de str`, `Cow<'de, str>`, `&'de [u8]`) directly from the event's row data, so a string-heavy row costs no per-field allocation. The event must outlive `T`.
+    pub fn deserialize_data_borrowed<'de, T: serde::Deserialize<'de>>(&'de self) -> Result<T> {
+        match &self.event_type {
+            EventType::Insert { data, .. } => data.deserialize_borrowed(),
+            EventType::Update { new_data, .. } => new_data.deserialize_borrowed(),
+            EventType::Delete { old_data, .. } => old_data.deserialize_borrowed(),
+            _ => Err(ReplicationError::deserialize(format!(
+                "event type '{}' does not contain row data",
+                self.event_type_str()
+            ))),
+        }
+    }
+
     pub fn event_type_str(&self) -> &str {
         match self.event_type {
             EventType::Insert { .. } => "insert",


### PR DESCRIPTION
## Summary

  Zero-copy **borrowed deserialization** plus two low-risk native-backend refinements and dead-code cleanup.

  - `RowData::deserialize_into<T: DeserializeOwned>` — signature and behavior **unchanged** (`String` fields still copy, exactly as before).
  - New `RowData::deserialize_borrowed<'de, T: Deserialize<'de>>(&'de self)` and `ChangeEvent::deserialize_data_borrowed` for the zero-copy  path.
  - No `unsafe`; borrows are lifetime-bound to the row, so a borrowed value cannot outlive the buffer (compiler-enforced; unit tests assert  pointer identity into the source buffer).


  ## Related issues
  
  n/a

  ## Type of change

  - [ ] Bug fix
  - [x] New feature
  - [x] Performance improvement
  - [x] Refactor / internal cleanup
  - [ ] Documentation
  - [ ] CI / build

  ## Checklist

  - [ ] `make before-git-push` passes locally (check, build, format, audit, test, doc-check) — verified individually: `cargo fmt --all
  --check`, `cargo clippy --all-targets`, `cargo test --lib`, and build all green on **both** backends; `audit`/`doc-check` not run locally
  (a pre-existing transitive `anyhow` RUSTSEC advisory is unrelated to this change)
  - [x] Tests added/updated for the change — new borrowed-path unit tests (borrowed `&str`/`&[u8]`, `Cow` borrows clean data, `Option<&str>`
  with NULL, owned-`String` still works) plus `benches/deserialize.rs`; coverage not measured locally
  - [x] Both backends build (`cargo build` default libpq + `cargo build --no-default-features --features rustls-tls`)
  - [ ] Docs / README updated if public API changed — rustdoc + examples added on the new methods; README not yet updated with a borrowed-API
  section
  
  ## Performance notes

  **Deserialization (`cargo bench --bench deserialize`, this branch):** borrowed vs owned on the same rows —
  
  | Shape | owned | borrowed | speedup |
  |---|---|---|---|
  | 8 string cols (32 B) | 237 ns | 109 ns | **2.17×** (−54%) |
  | 24 string cols (32 B) | 1026 ns | 370 ns | **2.77×** (−64%) |
  | 4 int + 4 string | 120 ns | 62 ns | 1.94× (−48%) |
  
  Consistent −46% to −64% across narrow/wide/short/long/mixed shapes; the win scales with the number of string fields.
