### PR TITLE
Enhance performance and ergonomics:

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -64,8 +64,11 @@ Convenience API on top of the core streaming primitives, all `Send + 'static`:
 - `EventStream::for_each_event(|ev| async {...})` — consume loop that auto-advances
   the applied LSN after each `Ok` handler; `Cancelled` → graceful exit.
 - `WalRouter` — routes by `(table, kind)` to typed async handlers
-  (`on_insert/on_update/on_delete/on_default`, `dispatch`, `run`). Heap-allocates one
-  boxed future per event; perf-critical consumers use `next_event`/`for_each_event`.
+  (`on_insert/on_update/on_delete/on_default`, `dispatch`, `run`). Its `default`
+  is `Option<Handler>`: with no `on_default` registered, unhandled events (unrouted
+  DML + all non-DML control events) return `Ok(())` directly — no boxed-future
+  allocation. Registered handlers still box one future per event; perf-critical
+  consumers use `next_event`/`for_each_event`.
 - `#[derive(WalTable)] #[wal(table = "...")]` (opt-in `derive` feature) + the
   `on_insert_of::<T>/on_update_of::<T>/on_delete_of::<T>` router methods infer the
   table from `T::TABLE`. Derive-using tests are `#[cfg(all(test, feature = "derive"))]`.
@@ -76,9 +79,15 @@ The performance-critical path is: `get_copy_data_async` → `process_wal_message
 
 Key optimizations in place:
 - Zero-copy `Bytes` throughout (no memcpy on WAL data)
+- libpq COPY ingress copies each message into a reusable `BytesMut` read buffer
+  (`put_slice` + `split().freeze()`), then `PQfreemem`s libpq's allocation
+  immediately; the backing allocation is reused after warmup (one memcpy into
+  cache-hot memory, bounded peak RSS). A `from_owner` zero-copy variant was
+  benchmarked and reverted — no measurable win outside noise.
 - `SmallVec<[ColumnData; 16]>` avoids heap alloc for ≤16 columns
 - Identity hasher for OID-keyed RelationMap (no SipHash)
-- Cache-padded atomics in SharedLsnFeedback (no false sharing)
+- Cache-padded atomics in SharedLsnFeedback (no false sharing); `update_applied_lsn`
+  folds the implicit-flush bump into a single `fetch_max` (Relaxed CAS seed)
 - SIMD-accelerated `memchr` for null-terminated string scanning
 - `Arc<str>` for namespace/relation_name (parsed directly, no String intermediate)
 - Feedback syscall throttling (Instant::now() every 128 events)

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -43,8 +43,8 @@ body:
     attributes:
       label: Connection backend
       options:
-        - libpq (default)
-        - rustls-tls (pure-Rust)
+        - rustls-tls (default, pure-Rust)
+        - libpq (opt-in)
         - not sure
     validations:
       required: true

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -30,7 +30,9 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         sudo apt-get update
-        sudo apt-get install -y libpq-dev pkg-config libssl-dev
+        # Default backend is rustls-tls (aws-lc-rs) — needs only cmake + a C
+        # compiler (preinstalled). No libpq / OpenSSL / pkg-config on this path.
+        sudo apt-get install -y cmake
 
     - name: Cache cargo registry
       uses: actions/cache@v4
@@ -67,6 +69,45 @@ jobs:
     - name: Run unit tests (derive feature)
       run: cargo test --lib --features derive --verbose
 
+  libpq-backend:
+    name: libpq backend (pq-sys, clean env)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Install Rust
+      uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+
+    # Clean, minimal environment for the opt-in libpq backend: only libpq +
+    # OpenSSL + pkg-config. Deliberately NO clang/libclang (pq-sys ships
+    # pre-generated bindings — no bindgen) and NO cmake (no aws-lc-rs on this
+    # path). If this job builds, the libpq/pq-sys backend needs nothing more.
+    - name: Install dependencies (libpq only)
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libpq-dev libssl-dev pkg-config
+
+    - name: Cache cargo registry
+      uses: actions/cache@v4
+      with:
+        path: |
+          ~/.cargo/registry
+          ~/.cargo/git
+        key: ${{ runner.os }}-cargo-libpq-${{ hashFiles('**/Cargo.lock') }}
+        restore-keys: |
+          ${{ runner.os }}-cargo-libpq-
+
+    - name: Build (libpq / pq-sys)
+      run: cargo build --no-default-features --features libpq --verbose
+
+    - name: Clippy (libpq / pq-sys)
+      run: cargo clippy --no-default-features --features libpq --all-targets -- -D warnings
+
+    - name: Unit tests (libpq / pq-sys)
+      run: cargo test --lib --no-default-features --features libpq --verbose
+
   coverage:
     name: Code Coverage
     runs-on: ubuntu-latest
@@ -82,7 +123,8 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libpq-dev pkg-config libssl-dev
+        # Coverage runs on the default rustls-tls backend (aws-lc-rs): cmake only.
+        sudo apt-get install -y cmake
 
     - name: Install cargo-llvm-cov
       uses: taiki-e/install-action@cargo-llvm-cov
@@ -162,7 +204,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update
-        sudo apt-get install -y libpq-dev pkg-config libssl-dev
+        sudo apt-get install -y libpq-dev pkg-config libssl-dev cmake
 
     - name: Cache cargo registry
       uses: actions/cache@v4
@@ -249,7 +291,7 @@ jobs:
         PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
           -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
 
-        cargo test --test pg_result_get_bytes -- --ignored --nocapture --test-threads=1
+        cargo test --test pg_result_get_bytes --no-default-features --features libpq -- --ignored --nocapture --test-threads=1
 
         PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
           -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,88 @@
+# AGENTS.md — pg-walstream
+
+Guidance for AI coding agents working in this repository. `.claude/CLAUDE.md`
+holds the same guidance for Claude Code; keep the two in sync when either changes.
+
+pg-walstream is a Rust library that parses the PostgreSQL logical/physical
+replication protocol and streams WAL (CDC) to any destination. The core is a
+zero-copy, allocation-conscious hot path; a thin ergonomics layer sits on top.
+
+## Build & Test
+
+```bash
+cargo build                                              # default: libpq backend
+cargo build --no-default-features --features rustls-tls  # pure-Rust TLS backend
+cargo test --lib                                         # unit tests (no PostgreSQL)
+cargo test --lib --features derive                       # + derive-macro layer
+cargo test --lib --no-default-features --features rustls-tls
+cargo bench --bench wal_pipeline                         # parsing pipeline benches
+cargo fmt --all -- --check                               # format check
+cargo clippy --all-targets                               # lint
+make before-git-push                                     # check+build+fmt+audit+test+doc-check
+```
+
+Integration tests (`integration-tests/`) are `#[ignore]` and need a live
+PostgreSQL 15+ with `wal_level = logical`; they only run in CI (`--ignored`).
+Do not edit them unless working on connection/streaming behavior.
+
+## Architecture
+
+```
+src/
+├── buffer.rs        # zero-copy BufferReader/BufferWriter (bytes crate)
+├── protocol.rs      # WAL message parser (hot path); RelationInfo, ReplicationState
+├── stream.rs        # LogicalReplicationStream + EventStream + config builder
+├── router.rs        # WalRouter: typed async by-table event router (convenience)
+├── deserializer.rs  # serde Deserializer: RowData → user structs
+├── column_value.rs  # ColumnValue / RowData
+├── types.rs         # EventType/ChangeEvent, Lsn, wire encode/decode
+├── lsn.rs           # thread-safe SharedLsnFeedback (atomic CAS)
+└── connection/      # libpq FFI backend (default) + native/ rustls-tls backend
+macros/              # #[derive(WalTable)] (opt-in `derive` feature)
+```
+
+## Hot Path
+
+Critical path: `get_copy_data_async` → `process_wal_message` →
+`parse_wal_message_bytes` → `parse_insert/update/delete_message` →
+`parse_tuple_data`. Optimizations in place:
+
+- Zero-copy `Bytes` throughout — no memcpy on WAL data.
+- libpq COPY ingress copies each message into a reusable `BytesMut` read buffer
+  (`put_slice` + `split().freeze()`), then `PQfreemem`s libpq's allocation
+  immediately. The backing allocation is reused after warmup, so the per-message
+  cost is one memcpy into cache-hot memory with a bounded peak RSS. (A `from_owner`
+  zero-copy variant was benchmarked against Azure PG and reverted — no measurable
+  throughput/CPU win outside noise; see git history.)
+- `SmallVec<[ColumnData; 16]>` avoids heap alloc for ≤16 columns.
+- Identity hasher for the OID-keyed RelationMap (no SipHash).
+- Cache-padded atomics in `SharedLsnFeedback`; `update_applied_lsn` folds the
+  implicit-flush bump into one `fetch_max` (with a Relaxed CAS seed load).
+- `WalRouter.default` is `Option<Handler>`: with no `on_default`, unhandled events
+  return `Ok(())` with no boxed-future allocation.
+- SIMD `memchr` for C-string scanning; `Arc<str>` for namespace/relation names;
+  feedback syscall throttling (`Instant::now()` every 128 events); no `debug!` in
+  DML parsers.
+
+## Coding Conventions
+
+- `#[inline]` on per-message hot-path methods; `#[inline(always)]` only for
+  trivial 1–2 instruction accessors; `#[cold] #[inline(never)]` for error-path
+  constructors.
+- Prefer `Bytes` over `Vec<u8>` for pipeline data; `Arc<str>` for shared
+  column/table names.
+- `BufferWriter` write methods are infallible (return `()`).
+- No `debug!` logging in DML hot-path parsers (BEGIN/INSERT/UPDATE/DELETE/COMMIT).
+- New `unsafe` (e.g. FFI buffer ownership) must carry a `// SAFETY:` note and a
+  runnable test proving the invariant (see the `Send` impls in `connection/libpq.rs`).
+
+## Public API stability
+
+Changing public types (e.g. `EventType` fields, `ChangeEvent` accessors) or the
+binary event wire format (`ChangeEvent::encode`/`decode`) is a breaking change —
+bump the minor version (0.x) and add a README "Upgrading" note.
+
+## CI Requirements
+
+`cargo fmt` clean · `cargo clippy` clean · `cargo test --lib` passes · coverage
+≥ 90% · `make before-git-push` green.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -84,28 +84,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
-name = "bindgen"
-version = "0.64.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4243e6031260db77ede97ad86c27e501d646a27ab57b59a574f725d98ab1fb4"
-dependencies = [
- "bitflags 1.3.2",
- "cexpr",
- "clang-sys",
- "lazy_static",
- "lazycell",
- "log",
- "peeking_take_while",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash",
- "shlex",
- "syn 1.0.109",
- "which",
-]
-
-[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -119,12 +97,6 @@ name = "bit-vec"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e764a1d40d510daf35e07be9eb06e75770908c27d411ee6c92109c9840eaaf7"
-
-[[package]]
-name = "bitflags"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
@@ -155,9 +127,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -178,15 +150,6 @@ dependencies = [
  "jobserver",
  "libc",
  "shlex",
-]
-
-[[package]]
-name = "cexpr"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
-dependencies = [
- "nom",
 ]
 
 [[package]]
@@ -243,17 +206,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "clang-sys"
-version = "1.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
-dependencies = [
- "glob",
- "libc",
- "libloading",
 ]
 
 [[package]]
@@ -533,7 +485,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -603,12 +555,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
-
-[[package]]
 name = "half"
 version = "2.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -647,15 +593,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6303bc9732ae41b04cb554b844a762b4115a61bfaa81e3e83050991eeb56863f"
 dependencies = [
  "digest",
-]
-
-[[package]]
-name = "home"
-version = "0.5.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc627f471c528ff0c4a49e1d5e60450c8f6461dd6d10ba9dcd3a61d3dff7728d"
-dependencies = [
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -745,18 +682,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "lazy_static"
-version = "1.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
-
-[[package]]
-name = "lazycell"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
-
-[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -767,33 +692,6 @@ name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
-
-[[package]]
-name = "libloading"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
-dependencies = [
- "cfg-if",
- "windows-link",
-]
-
-[[package]]
-name = "libpq-sys"
-version = "0.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ef060ac05c207c85da15f4eb629100c8782e0db4c06a3c91c86be9c18ae8a23"
-dependencies = [
- "bindgen",
- "pkg-config",
- "vcpkg",
-]
-
-[[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
 
 [[package]]
 name = "linux-raw-sys"
@@ -828,15 +726,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
-
-[[package]]
-name = "minimal-lexical"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mio"
@@ -847,16 +739,6 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "nom"
-version = "7.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
-dependencies = [
- "memchr",
- "minimal-lexical",
 ]
 
 [[package]]
@@ -914,18 +796,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "pg-walstream-macros"
 version = "0.7.0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -938,10 +814,10 @@ dependencies = [
  "criterion",
  "futures",
  "futures-core",
- "libpq-sys",
  "memchr",
  "pg-walstream-macros",
  "postgres-protocol",
+ "pq-sys",
  "proptest",
  "rustls",
  "serde",
@@ -1024,13 +900,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "pq-sys"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "574ddd6a267294433f140b02a726b0640c43cf7c6f717084684aaa3b285aba61"
+dependencies = [
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
 name = "prettyplease"
 version = "0.2.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1050,7 +937,7 @@ checksum = "4b45fcc2344c680f5025fe57779faef368840d0bd1f42f216291f0dc4ace4744"
 dependencies = [
  "bit-set",
  "bit-vec",
- "bitflags 2.11.1",
+ "bitflags",
  "num-traits",
  "rand 0.9.4",
  "rand_chacha",
@@ -1169,7 +1056,7 @@ version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
 ]
 
 [[package]]
@@ -1216,34 +1103,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "rustc-hash"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.11.1",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
-]
-
-[[package]]
 name = "rustix"
 version = "1.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -1359,7 +1227,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1446,17 +1314,6 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b9ae57f904213ebb649ce6895b8a66c66f0203b9319718f69a5612a065b1422"
@@ -1475,7 +1332,7 @@ dependencies = [
  "fastrand",
  "getrandom 0.4.2",
  "once_cell",
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
 ]
 
@@ -1529,7 +1386,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1712,7 +1569,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -1753,7 +1610,7 @@ version = "0.244.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
- "bitflags 2.11.1",
+ "bitflags",
  "hashbrown 0.15.5",
  "indexmap",
  "semver",
@@ -1776,18 +1633,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf85cb06032201fa7c6f829d7db5a7e5aa45bcc0655327713065f6f0576731bf"
 dependencies = [
  "rustls-pki-types",
-]
-
-[[package]]
-name = "which"
-version = "4.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
-dependencies = [
- "either",
- "home",
- "once_cell",
- "rustix 0.38.44",
 ]
 
 [[package]]
@@ -1842,7 +1687,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1853,7 +1698,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]
@@ -1885,15 +1730,6 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
-dependencies = [
- "windows-targets",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.59.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets",
 ]
@@ -2007,7 +1843,7 @@ dependencies = [
  "heck",
  "indexmap",
  "prettyplease",
- "syn 2.0.118",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2023,7 +1859,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2035,7 +1871,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
- "bitflags 2.11.1",
+ "bitflags",
  "indexmap",
  "log",
  "serde",
@@ -2082,7 +1918,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.118",
+ "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,22 +27,22 @@ homepage = "https://github.com/isdaniel/pg-walstream"
 rust-version = "1.87"
 
 [workspace.dependencies]
-pg-walstream-macros = { path = "macros", version = "=0.7.0" }
+pg-walstream-macros = { path = "macros", version = "0.7" }
 
 [dependencies]
 tokio = { version = "1.52.3", features = ["io-util", "net", "time", "macros", "rt", "rt-multi-thread"], optional = true }
 tokio-util = { version = "0.7.18", optional = true }
 serde = { version = "1.0.228", default-features = false, features = ["derive", "rc", "alloc"] }
 chrono = { version = "0.4.45", default-features = false, features = ["serde", "alloc"] }
-bytes = { version = "1.12.0", default-features = false, features = ["serde"] }
+bytes = { version = "1.12.1", default-features = false, features = ["serde"] }
 tracing = { version = "0.1.44", default-features = false }
 futures-core = { version = "0.3.32", default-features = false }
-memchr = { version = "2.8.2", default-features = false }
+memchr = { version = "2.8.3", default-features = false }
 smallvec = { version = "1.15.2", features = ["serde"] }
 pg-walstream-macros = { workspace = true, optional = true }
 
-# libpq backend (default)
-libpq-sys = { version = "0.8", optional = true }
+# libpq backend (opt-in) — pq-sys: raw FFI to the system libpq via pkg-config, with pre-generated bindings (no libclang/bindgen at build time).
+pq-sys = { version = "0.7.5", optional = true }
 
 # rustls-tls
 tokio-rustls = { version = "0.26.4", optional = true }
@@ -53,7 +53,7 @@ aws-lc-rs = { version = "1.17.1", optional = true }
 socket2 = { version = "0.6.4", features = ["all"], optional = true }
 
 [features]
-default = ["std", "libpq"]
+default = ["std", "rustls-tls"]
 derive = ["dep:pg-walstream-macros"]
 
 # Standard library support, on by default. Disable with `--no-default-features` for a no_std + alloc parser-only build (targets wasm and embedded).
@@ -67,7 +67,7 @@ std = [
     "memchr/std",
 ]
 
-libpq = ["dep:libpq-sys", "dep:tokio", "dep:tokio-util", "std"]
+libpq = ["dep:pq-sys", "dep:tokio", "dep:tokio-util", "std"]
 
 # Pure-Rust native backend: uses rustls with aws-lc-rs forhardware-accelerated TLS crypto (AES-NI, AVX2, SHA-NI), requires cmake + C compiler at build time.
 rustls-tls = [

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ A high-performance Rust library for PostgreSQL logical and physical replication 
 - **Full Logical Replication Support**: Implements PostgreSQL logical replication protocol versions 1-4
 - **Physical Replication Support**: Stream raw WAL data for standby servers and PITR
 - **Base Backup Support**: Full `BASE_BACKUP` command with progress, compression, and manifest options
-- **Pure-Rust Backend**: Optional `rustls-tls` feature eliminates all C dependencies (no libpq, no libclang), using `aws-lc-rs` for hardware-accelerated TLS (AES-NI, AVX2, SHA-NI)
+- **Pure-Rust Backend (default)**: The default `rustls-tls` backend needs no libpq and no OpenSSL, using `aws-lc-rs` for hardware-accelerated TLS (AES-NI, AVX2, SHA-NI) — ~2× more CPU-efficient than the optional C libpq backend
 - **TLS/SSL Support**: All PostgreSQL SSL modes (`disable`, `allow`, `prefer`, `require`, `verify-ca`, `verify-full`)
 - **Authentication**: Cleartext, MD5, and SCRAM-SHA-256 authentication methods
 - **Streaming Transactions**: Support for streaming large transactions (protocol v2+)
 - **Two-Phase Commit**: Prepared transaction support (protocol v3+)
 - **Parallel Streaming**: Multi-stream parallel replication (protocol v4+)
-- **Zero-Copy Operations**: Efficient buffer management using the `bytes` crate with drain-loop batch queue optimization
+- **Zero-Copy Operations**: Efficient buffer management using the `bytes` crate with drain-loop batch queue optimization. The libpq backend copies each COPY message into a reusable `BytesMut` buffer, then reference-counts it downstream as `Bytes` (no per-message heap allocation after warmup)
 - **Thread-Safe LSN Tracking**: Atomic LSN feedback for producer-consumer patterns
 - **Connection Management**: Built-in connection handling with exponential backoff retry logic
 - **Type-Safe API**: Strongly typed message parsing with comprehensive error handling
@@ -34,47 +34,42 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-pg_walstream = "0.6.3"
+pg_walstream = "0.7"
 ```
 
-By default, this uses the `libpq` backend (C FFI). To switch to a **pure-Rust** build:
+By default, this uses the pure-Rust `rustls-tls` backend — no libpq and no OpenSSL, only `cmake` + a C compiler at build time (for `aws-lc-rs`).
+
+To use the C **libpq** backend instead (bound by `pq-sys`; requires system libpq):
 
 ```toml
 [dependencies]
-pg_walstream = { version = "0.6.3", features = ["rustls-tls"] }
+pg_walstream = { version = "0.7", default-features = false, features = ["libpq"] }
 ```
 
-When `rustls-tls` is enabled alongside the default `libpq`, `rustls-tls` takes priority automatically — no need to set `default-features = false`.
-
-For a fully pure-Rust build with **no system dependencies** (avoids building `libpq-sys` entirely):
-
-```toml
-[dependencies]
-pg_walstream = { version = "0.6.3", default-features = false, features = ["rustls-tls"] }
-```
+If both backends are enabled, `rustls-tls` takes priority automatically.
 
 ## Feature Flags
 
-pg-walstream provides two connection backends plus a `std` toggle, all selected at compile time. When both backends are enabled, `rustls-tls` takes priority:
+pg-walstream provides two connection backends plus a `std` toggle, all selected at compile time. `rustls-tls` is the default; `libpq` is opt-in. When both are enabled, `rustls-tls` takes priority:
 
 | Feature | Default | C Dependencies | Description |
 |---------|---------|----------------|-------------|
 | `std` | Yes | None | Standard library support. Disable with `default-features = false` for a `no_std` plus `alloc` parser-only build (no connection layer) that compiles for `wasm32-unknown-unknown` and embedded targets. |
-| `libpq` | Yes | `libpq-dev`, `libclang-dev` | Uses PostgreSQL's C client library via FFI. Battle-tested, supports all auth methods natively. Implies `std`. |
-| `rustls-tls` | No | `cmake`, `gcc` (build-time only) | Pure-Rust implementation using `rustls` with `aws-lc-rs` crypto backend for hardware-accelerated TLS. No runtime C dependencies. Takes priority when both backends are enabled. Implies `std`. |
+| `libpq` | No | `libpq-dev` + OpenSSL | Opt-in. PostgreSQL's C client library via FFI, bound by `pq-sys` (pre-generated bindings — no libclang). Battle-tested. Enable with `--no-default-features --features libpq`. Implies `std`. |
+| `rustls-tls` | Yes | `cmake`, `gcc` (build-time only) | Default. Pure-Rust implementation using `rustls` with `aws-lc-rs` crypto backend for hardware-accelerated TLS. No libpq, no OpenSSL, no runtime C dependencies. Takes priority when both backends are enabled. Implies `std`. |
 | `derive` | No | None | Opt-in proc-macros (pull `syn`/`quote`) that bind a struct to a table — `#[derive(WalTable)] #[wal(table = "...")]` or the one-line attribute form `#[wal_table("...")]` — enabling the `WalRouter::on_insert_of::<T>` / `on_update_of::<T>` / `on_delete_of::<T>` table-inference methods. |
 
 > **Note:** The protocol parser, encoder, and types need no backend. Building with `default-features = false` gives a `no_std` plus `alloc` build of just those, suitable for wasm and embedded. A connection backend (`libpq` or `rustls-tls`) is required only for the live streaming and connection APIs, and pulls in `std`.
 
 ## System Dependencies
 
-System dependencies are **only required** when using the default `libpq` feature. The `rustls-tls` feature requires only `cmake` and a C compiler at build time (for the `aws-lc-rs` crypto library), with no runtime dependencies.
+System dependencies are **only required** for the opt-in `libpq` feature. The default `rustls-tls` backend requires only `cmake` and a C compiler at build time (for the `aws-lc-rs` crypto library), with no runtime dependencies.
 
-### For `libpq` feature (default)
+### For `libpq` feature (opt-in)
 
 **Ubuntu/Debian:**
 ```bash
-sudo apt-get install libpq-dev clang libclang-dev
+sudo apt-get install libpq-dev libssl-dev
 ```
 
 **CentOS/RHEL/Fedora:**
@@ -97,7 +92,7 @@ sudo apt-get install cmake gcc
 Then add to `Cargo.toml`:
 
 ```toml
-pg_walstream = { version = "0.6.3", features = ["rustls-tls"] }
+pg_walstream = { version = "0.7", features = ["rustls-tls"] }
 ```
 
 #### TLS trust store
@@ -341,8 +336,8 @@ The library supports all PostgreSQL logical replication message types:
 │  │  libpq backend  │ rustls-tls       │  │
 │  │  (C FFI)        │ (pure Rust)      │  │
 │  │                 │                  │  │
-│  │  libpq-sys      │ rustls +         │  │
-│  │  + libclang     │ aws-lc-rs +      │  │
+│  │  pq-sys         │ rustls +         │  │
+│  │                 │ aws-lc-rs +      │  │
 │  │                 │ postgres-protocol│  │
 │  └─────────────────┴──────────────────┘  │
 │  Compile-time feature flag selection     │

--- a/load-tests/Cargo.lock
+++ b/load-tests/Cargo.lock
@@ -51,9 +51,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.17.0"
+version = "1.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
+checksum = "4342d8937fc7e5dd9b1c60292261c0670c882a2cd1719cfc11b1af41731e32ad"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -62,14 +62,15 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.41.0"
+version = "0.42.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
+checksum = "6d9ceb1da931507a12f4fccea479dccd00da1943e1b4ae72d8e502d707361444"
 dependencies = [
  "cc",
  "cmake",
  "dunce",
  "fs_extra",
+ "pkg-config",
 ]
 
 [[package]]
@@ -141,9 +142,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.12.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ae3f5d315924270530207e2a68396c3cc547f6dca3fbdca317cfb1a51edb593"
+checksum = "fc652a48c352aef3ea3aed32080501cf3ef6ed5da78602a020c991775b0aff04"
 dependencies = [
  "serde",
 ]
@@ -726,9 +727,9 @@ dependencies = [
 
 [[package]]
 name = "memchr"
-version = "2.8.2"
+version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "minimal-lexical"

--- a/src/connection/libpq.rs
+++ b/src/connection/libpq.rs
@@ -1,4 +1,4 @@
-//! Low-level PostgreSQL connection using libpq-sys
+//! Low-level PostgreSQL connection using pq-sys (raw FFI bindings to libpq)
 //!
 //! This module provides safe wrappers around libpq functions for logical replication.
 //! It relies on libpq and requires the libpq development libraries at build time.
@@ -37,7 +37,7 @@ use crate::types::{
     SlotType, XLogRecPtr,
 };
 use bytes::{BufMut, Bytes, BytesMut};
-use libpq_sys::*;
+use pq_sys::*;
 use std::collections::VecDeque;
 use std::ffi::{CStr, CString};
 use std::os::raw::c_void;
@@ -1666,6 +1666,16 @@ mod tests {
         }
     }
 
+    /// The libpq wire ABI fixes these status-enum discriminants; the `pq-sys` binding must agree with them. Guards against a future bindgen/libpq drift.
+    #[test]
+    fn status_enum_abi_values_match_libpq() {
+        assert_eq!(ConnStatusType::CONNECTION_OK as i32, 0);
+        assert_eq!(ExecStatusType::PGRES_COMMAND_OK as i32, 1);
+        assert_eq!(ExecStatusType::PGRES_TUPLES_OK as i32, 2);
+        assert_eq!(ExecStatusType::PGRES_COPY_OUT as i32, 3);
+        assert_eq!(ExecStatusType::PGRES_COPY_BOTH as i32, 8);
+    }
+
     // ========================================
     // build_drop_slot_sql tests
     // ========================================
@@ -2291,7 +2301,7 @@ mod tests {
     /// One-row `PgResult` built via libpq's result API (no server). `None` is a
     /// SQL NULL cell, `Some(bytes)` a binary value (len may be 0).
     fn make_bytea_result(cells: &[Option<&[u8]>]) -> PgResult {
-        use libpq_sys::{
+        use pq_sys::{
             ExecStatusType, PGresAttDesc, PQmakeEmptyPGresult, PQsetResultAttrs, PQsetvalue,
         };
         use std::os::raw::{c_char, c_int};

--- a/src/connection/mod.rs
+++ b/src/connection/mod.rs
@@ -3,20 +3,20 @@
 //! This module provides two interchangeable connection implementations,
 //! selected at compile time via feature flags:
 //!
-//! - **`libpq`** (default): Uses the C libpq library via FFI. Requires
+//! - **`libpq`** (opt-in): Uses the C libpq library via FFI. Requires
 //!   `libpq-dev` and `libssl-dev` at build time.
 //!
-//! - **`rustls-tls`**: Pure-Rust implementation using `rustls` with the
+//! - **`rustls-tls`** (default): Pure-Rust implementation using `rustls` with the
 //!   `aws-lc-rs` crypto backend for hardware-accelerated TLS (AES-NI, AVX2).
 //!   Requires `cmake` + C compiler at build time.
-//!   When enabled alongside the default `libpq` feature, `rustls-tls` takes
-//!   priority so that `features = ["rustls-tls"]` works without needing
-//!   `default-features = false`.
+//!   This is the default backend; enable `libpq` instead with
+//!   `--no-default-features --features libpq`. When both are enabled,
+//!   `rustls-tls` takes priority.
 //!
 //! Both backends expose the same public types: `PgReplicationConnection` and
 //! `PgResult`.
 
-// ── libpq backend (default) ──────────────────────────────────────────────────
+// ── libpq backend (opt-in) ───────────────────────────────────────────────────
 
 #[cfg(all(feature = "libpq", not(feature = "rustls-tls")))]
 mod libpq;

--- a/src/connection/native/copy.rs
+++ b/src/connection/native/copy.rs
@@ -34,7 +34,12 @@ const READ_CHUNK: usize = 256 * 1024;
 /// Using `READ_CHUNK` itself as the threshold would realloc on almost every
 /// read: after each drain, frozen slices pin the buffer so `reserve` can't
 /// reclaim, and the remaining headroom sits just below `READ_CHUNK` → reserve fires and reallocs every iteration. Checking against this smaller threshold lets one 256 KiB reservation serve many reads before the next top-up.
-const MIN_HEADROOM: usize = 64 * 1024;
+///
+/// Pinned strictly greater than [`startup::TLS_BUF_SIZE`](super::startup::TLS_BUF_SIZE): at read time `read_buf` always has more free space than the TLS `BufReader`'s internal buffer, so tokio's `BufReader` bypasses its own buffer and decrypts
+/// straight into `read_buf` — no intermediate copy on the streaming hot path.
+/// The `const` assert below enforces the coupling at compile time (previously the two happened to be equal, which held only by coincidence).
+const MIN_HEADROOM: usize = super::startup::TLS_BUF_SIZE + 4 * 1024;
+const _: () = assert!(MIN_HEADROOM > super::startup::TLS_BUF_SIZE);
 
 /// Read the next CopyData payload from the replication stream.
 ///

--- a/src/connection/native/startup.rs
+++ b/src/connection/native/startup.rs
@@ -43,7 +43,10 @@ fn crypto_provider() -> Arc<rustls::crypto::CryptoProvider> {
 /// - A single TLS record payload is at most 16,384 bytes (2^14, per RFC 8446).
 /// - `postgres-openssl` and `postgres-native-tls` use 8,192 (one typical record).
 /// - For **replication streaming**, we use 65,536 so one `read()` can pull several maximum-size TLS records at once. The CopyData drain loop (`copy::drain_read_buffer`) then parses more WAL messages per wakeup,  cutting syscalls and — on the worker-thread driver — cross-thread batch handoffs during sustained high-throughput WAL consumption.
-const TLS_BUF_SIZE: usize = 65_536;
+///
+/// Exposed `pub(crate)` so `copy.rs` can pin its read-headroom invariant
+/// (`MIN_HEADROOM > TLS_BUF_SIZE`) to this value at compile time, guaranteeing tokio's `BufReader` always bypasses its buffer on the CopyData hot path.
+pub(crate) const TLS_BUF_SIZE: usize = 65_536;
 
 /// The transport layer — either plain TCP or TLS-wrapped TCP.
 ///

--- a/src/lsn.rs
+++ b/src/lsn.rs
@@ -107,7 +107,7 @@ impl SharedLsnFeedback {
             return;
         }
 
-        let mut current = self.flushed_lsn.load(Ordering::Acquire);
+        let mut current = self.flushed_lsn.load(Ordering::Relaxed);
         loop {
             if lsn <= current {
                 return;
@@ -141,7 +141,7 @@ impl SharedLsnFeedback {
             return;
         }
 
-        let mut current = self.applied_lsn.load(Ordering::Acquire);
+        let mut current = self.applied_lsn.load(Ordering::Relaxed);
         let mut advanced = false;
         loop {
             if lsn <= current {
@@ -165,9 +165,10 @@ impl SharedLsnFeedback {
             }
         }
 
-        // Applied data is implicitly flushed. Only chase the flushed CAS when we actually moved applied forward; otherwise flushed cannot be behind.
+        // Applied data is implicitly flushed. Only chase flushed when we actually moved applied forward; otherwise flushed cannot be behind.
+        // A single `fetch_max` RMW replaces a second load+CAS loop: `lsn` is guaranteed non-zero (early return above) and, since we just advanced applied past `current`, `lsn` also exceeds any legitimate flushed value, so the max is monotonic and correct. `Release` publishes it for the `Acquire` reader in `get_feedback_lsn`.
         if advanced {
-            self.update_flushed_lsn(lsn);
+            self.flushed_lsn.fetch_max(lsn, Ordering::Release);
         }
     }
 

--- a/src/router.rs
+++ b/src/router.rs
@@ -39,7 +39,7 @@ enum Kind {
 /// `next_event()` and match event types by hand), returning `Ok(())` to skip.
 pub struct WalRouter {
     handlers: HashMap<(Arc<str>, Kind), Handler>,
-    default: Handler,
+    default: Option<Handler>,
 }
 
 impl Default for WalRouter {
@@ -53,7 +53,7 @@ impl WalRouter {
     pub fn new() -> Self {
         Self {
             handlers: HashMap::new(),
-            default: Box::new(|_ev| Box::pin(async { Ok(()) })),
+            default: None,
         }
     }
 
@@ -122,7 +122,7 @@ impl WalRouter {
         F: FnMut(&ChangeEvent) -> Fut + Send + 'static,
         Fut: Future<Output = Result<()>> + Send + 'static,
     {
-        self.default = Box::new(move |ev| Box::pin(f(ev)) as BoxFut);
+        self.default = Some(Box::new(move |ev| Box::pin(f(ev)) as BoxFut));
         self
     }
 
@@ -138,11 +138,13 @@ impl WalRouter {
             EventType::Delete { table, .. } => Some((table.clone(), Kind::Delete)),
             _ => None,
         };
-        let fut = match key.as_ref().and_then(|k| self.handlers.get_mut(k)) {
-            Some(h) => h(ev),
-            None => (self.default)(ev),
-        };
-        fut.await
+        match key.as_ref().and_then(|k| self.handlers.get_mut(k)) {
+            Some(h) => h(ev).await,
+            None => match self.default.as_mut() {
+                Some(d) => d(ev).await,
+                None => Ok(()),
+            },
+        }
     }
 
     /// Drive an [`EventStream`]: dispatch each event, auto-advance applied LSN


### PR DESCRIPTION
feat(connection): adopt pq-sys as the libpq FFI binding (replaces libpq-sys)

- Refactor WalRouter to use Option<Handler> for unhandled events.
- Optimize memory management in PgReplicationConnection by removing unnecessary read buffer.
- Update dependencies: bytes to 1.12.1, memchr to 2.8.3, aws-lc-rs to 1.17.1, and aws-lc-sys to 0.42.0.
- Introduce PqCopyBuf for zero-copy handling of libpq COPY buffer.
- Adjust LSN tracking to use relaxed ordering for performance improvements.
- Document architecture and hot path optimizations in AGENTS.md.


Runtime-identical (proven by A/B: within noise floor). Motivation is maintenance + build ergonomics: pq-sys is actively released (6x in 2025, Diesel-backed, ~13x downloads) vs libpq-sys last shipped 2023; and pq-sys ships pre-generated bindings so the libpq backend no longer needs libclang/bindgen at build time. Non-breaking: same libpq via pkg-config, public API and `libpq` feature unchanged.

feat: make rustls-tls the default backend (libpq now opt-in)

The pure-Rust rustls-tls backend is ~2x more CPU-efficient than libpq/OpenSSL (repo benchmark) and needs no libpq and no OpenSSL. libpq (pq-sys) remains available via --no-default-features --features libpq.

- new libpq-backend job builds+tests --no-default-features --features libpq with only libpq-dev/libssl-dev/pkg-config (proves pq-sys needs no libclang/bindgen)
- pg_result_get_bytes now runs under --features libpq (was 0 tests on rustls default)
- add cmake to the default (rustls-tls/aws-lc-rs) build jobs

ci: rustls-default jobs need only cmake (drop unused libpq-dev/pkg-config/libssl-dev)

The default (rustls-tls) build pulls aws-lc-rs (cmake + cc), not pq-sys/openssl-sys, so the Test Suite and Coverage jobs no longer need libpq-dev/pkg-config/libssl-dev. Integration keeps them (pg_result_get_bytes runs under --features libpq); the libpq-backend clean-env job is unchanged.