### PR TITLE
feat(config): add stop_at_lsn field + with_stop_at_lsn builder

### DIFF
--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -300,6 +300,12 @@ jobs:
         # on_*_of) — the derive module is #[cfg(feature = "derive")].
         cargo test --test ergonomics --features derive -- --ignored --nocapture --test-threads=1
 
+        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
+          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+
+        # Bounded replay: stream to a target LSN, stop cleanly at the commit boundary.
+        cargo test --test bounded_replay -- --ignored --nocapture --test-threads=1
+
   integration-ssl:
     name: SSL Integration Tests (PG ${{ matrix.pg_version }})
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -136,6 +136,10 @@ path = "integration-tests/binary_columns.rs"
 name = "ergonomics"
 path = "integration-tests/ergonomics.rs"
 
+[[test]]
+name = "bounded_replay"
+path = "integration-tests/bounded_replay.rs"
+
 [[bench]]
 name = "wal_pipeline"
 harness = false

--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ A high-performance Rust library for PostgreSQL logical and physical replication 
 - **Type-Safe API**: Strongly typed message parsing with comprehensive error handling
 - **Typed Row Deserialization**: Built-in `serde` deserializer maps WAL rows directly into user-defined Rust structs (numerics, `bool`, `String`, `Option<T>`, enums, bytes)
 - **High-Level Consumption Ergonomics**: `ReplicationStreamConfig::builder()`, an auto-acking `EventStream::for_each_event`, and a typed by-table `WalRouter` with an optional `#[derive(WalTable)]` layer (opt-in `derive` feature)
+- **Bounded Replay**: `ReplicationStreamConfig::with_stop_at_lsn` streams to a target LSN, delivers the crossing transaction in full, then ends cleanly with `ReplicationError::StreamStopped`
 - **Replication Slot Management**: Create, alter, read, and drop slots with full option support
 - **Hot Standby Feedback**: Send hot standby feedback messages for physical replication
 

--- a/integration-tests/bounded_replay.rs
+++ b/integration-tests/bounded_replay.rs
@@ -1,0 +1,155 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
+//! Integration test for `stop_at_lsn` bounded replay.
+//!
+//! Requires a live PostgreSQL with `wal_level = logical`. Run with:
+//!   export DATABASE_URL="postgresql://user:pass@host:5432/db?replication=database"
+//!   cargo test --test bounded_replay -- --ignored --nocapture --test-threads=1
+
+use pg_walstream::{
+    EventType, LogicalReplicationStream, Lsn, PgReplicationConnection, ReplicationError,
+    ReplicationStreamConfig, RetryConfig, StreamingMode,
+};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+fn replication_conn_string() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+            .to_string()
+    })
+}
+
+fn regular_conn_string() -> String {
+    std::env::var("DATABASE_URL_REGULAR").unwrap_or_else(|_| {
+        let repl = replication_conn_string();
+        repl.replace("?replication=database", "")
+            .replace("&replication=database", "")
+    })
+}
+
+fn drop_slot(slot_name: &str) {
+    if let Ok(mut conn) = PgReplicationConnection::connect(&replication_conn_string()) {
+        let _ = conn.exec(&format!(
+            "SELECT pg_drop_replication_slot('{slot_name}') \
+             WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{slot_name}')"
+        ));
+    }
+}
+
+fn cfg(slot: &str) -> ReplicationStreamConfig {
+    // Persistent (non-temporary) slot, non-streaming commits for simple assertions.
+    ReplicationStreamConfig::new(
+        slot.to_string(),
+        "bounded_pub".to_string(),
+        2,
+        StreamingMode::Off,
+        Duration::from_secs(10),
+        Duration::from_secs(30),
+        Duration::from_secs(60),
+        RetryConfig::default(),
+    )
+}
+
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn stop_at_lsn_bounds_replay_at_commit_boundary() {
+    let slot = "it_bounded_replay";
+    drop_slot(slot);
+
+    // --- Setup schema + publication over a regular connection ---
+    let mut regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    let _ = regular.exec(
+        "CREATE TABLE IF NOT EXISTS bounded_test (id SERIAL PRIMARY KEY, payload TEXT NOT NULL)",
+    );
+    let _ = regular.exec("TRUNCATE bounded_test RESTART IDENTITY");
+    let _ = regular.exec("DROP PUBLICATION IF EXISTS bounded_pub");
+    regular
+        .exec("CREATE PUBLICATION bounded_pub FOR TABLE bounded_test")
+        .expect("create publication");
+
+    // Create the persistent logical slot BEFORE the transactions so it captures
+    // them. A regular (non-replication) connection can call this function.
+    regular
+        .exec(&format!(
+            "SELECT pg_create_logical_replication_slot('{slot}', 'pgoutput')"
+        ))
+        .expect("create slot");
+
+    // --- Three transactions BEFORE the target ---
+    for i in 1..=3 {
+        regular
+            .exec(&format!(
+                "INSERT INTO bounded_test (payload) VALUES ('before_{i}')"
+            ))
+            .expect("insert before target");
+    }
+
+    // Force WAL to advance past txn3's commit record so `target` lands STRICTLY
+    // between txn3 and txn4. Without this, `pg_current_wal_lsn()` can equal
+    // txn3's commit `end_lsn`; since the stop rule is `end_lsn >= target`, txn3
+    // would then satisfy it and the stream would stop one commit early.
+    let _ = regular.exec("SELECT pg_switch_wal()");
+
+    // Capture a target LSN strictly after txn3's commit and before txn4.
+    let target: Lsn = regular
+        .exec("SELECT pg_current_wal_lsn()")
+        .expect("current wal lsn")
+        .get_value(0, 0)
+        .expect("lsn value")
+        .parse()
+        .expect("parse lsn");
+
+    // --- Two more transactions AFTER the target (must NOT be fully delivered) ---
+    for i in 4..=5 {
+        regular
+            .exec(&format!(
+                "INSERT INTO bounded_test (payload) VALUES ('after_{i}')"
+            ))
+            .expect("insert after target");
+    }
+
+    // --- Bounded stream on the same slot ---
+    let mut stream = LogicalReplicationStream::new(
+        &replication_conn_string(),
+        cfg(slot).with_stop_at_lsn(target),
+    )
+    .await
+    .expect("replication stream");
+    stream.start(None).await.expect("start");
+
+    let cancel = CancellationToken::new();
+    let mut commits = 0u32;
+    let mut inserts = 0u32;
+
+    let reached: Lsn = loop {
+        match stream.next_event(&cancel).await {
+            Ok(event) => match event.event_type {
+                EventType::Insert { .. } => inserts += 1,
+                EventType::Commit { .. } => commits += 1,
+                _ => {}
+            },
+            Err(ReplicationError::StreamStopped(lsn)) => break lsn,
+            Err(e) => panic!("unexpected error: {e}"),
+        }
+    };
+
+    // txn1..3 have end_lsn < target (no stop); txn4 is the first commit whose
+    // end_lsn >= target → stream stops AFTER delivering txn4. So exactly 4
+    // commits are delivered and txn5 is never seen.
+    assert_eq!(
+        commits, 4,
+        "should deliver txn1..4 (the crossing commit) then stop"
+    );
+    assert!(inserts >= 4, "should have delivered at least four inserts");
+    assert!(
+        reached.value() >= target.value(),
+        "reported stop LSN {reached} must be >= target {target}"
+    );
+
+    // Drop the stream so the slot becomes inactive, then clean it up.
+    drop(stream);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    drop_slot(slot);
+}

--- a/src/connection/libpq.rs
+++ b/src/connection/libpq.rs
@@ -573,6 +573,68 @@ impl PgReplicationConnection {
         }
     }
 
+    /// Send a client CopyDone (`PQputCopyEnd`) to end the COPY stream cleanly.
+    ///
+    /// Idempotent: a no-op when not in replication mode. The non-blocking flush loop mirrors `put_copy_data_and_flush`. Trailing results are reclaimed by `PQfinish` on drop (matching `close_replication_connection`), so we do not drain `PQgetResult` here.
+    pub(crate) async fn end_copy(&mut self) -> Result<()> {
+        if !self.is_replication_conn {
+            return Ok(());
+        }
+        // Mark the copy ended up front: even if a flush below errors out, this keeps `close_replication_connection` on drop from redundantly re-sending CopyEnd on an already-half-closed connection.
+        self.is_replication_conn = false;
+        // PQputCopyEnd: 1 = queued, 0 = would block (nonblocking mode), -1 = err.
+        loop {
+            let r = unsafe { PQputCopyEnd(self.conn, ptr::null()) };
+            match r {
+                1 => break,
+                0 => {
+                    // Would block: drain libpq's output buffer with PQflush before retrying. Just waiting for writability without flushing would spin — the socket stays writable while the buffer is never emptied, and PQputCopyEnd keeps returning 0.
+                    let flush = unsafe { PQflush(self.conn) };
+                    if flush < 0 {
+                        let msg = self.last_error_message();
+                        return Err(ReplicationError::protocol(format!("PQflush failed: {msg}")));
+                    }
+                    if flush == 1 {
+                        let async_fd = self.async_fd.as_ref().ok_or_else(|| {
+                            ReplicationError::protocol("AsyncFd not initialized".to_string())
+                        })?;
+                        let mut guard = async_fd.writable().await.map_err(|e| {
+                            ReplicationError::protocol(format!("wait writable failed: {e}"))
+                        })?;
+                        guard.clear_ready();
+                    }
+                }
+                _ => {
+                    let msg = self.last_error_message();
+                    return Err(ReplicationError::protocol(format!(
+                        "PQputCopyEnd failed: {msg}"
+                    )));
+                }
+            }
+        }
+        // Flush the CopyDone to the socket (same non-blocking loop as feedback).
+        loop {
+            let flush = unsafe { PQflush(self.conn) };
+            match flush {
+                0 => break,
+                1 => {
+                    let async_fd = self.async_fd.as_ref().ok_or_else(|| {
+                        ReplicationError::protocol("AsyncFd not initialized".to_string())
+                    })?;
+                    let mut guard = async_fd.writable().await.map_err(|e| {
+                        ReplicationError::protocol(format!("wait writable failed: {e}"))
+                    })?;
+                    guard.clear_ready();
+                }
+                _ => {
+                    let msg = self.last_error_message();
+                    return Err(ReplicationError::protocol(format!("PQflush failed: {msg}")));
+                }
+            }
+        }
+        Ok(())
+    }
+
     /// Check if the connection is still alive
     pub fn is_alive(&self) -> bool {
         if self.conn.is_null() {
@@ -1237,6 +1299,13 @@ mod tests {
         let mut conn = PgReplicationConnection::null_for_testing();
         conn.close_replication_connection(); // should not panic
         assert!(conn.conn.is_null());
+    }
+
+    #[tokio::test]
+    async fn end_copy_noop_when_not_replication_conn() {
+        // A conn that is not in replication mode must no-op without touching FFI.
+        let mut conn = PgReplicationConnection::null_for_testing();
+        assert!(conn.end_copy().await.is_ok());
     }
 
     #[test]

--- a/src/connection/libpq.rs
+++ b/src/connection/libpq.rs
@@ -587,20 +587,29 @@ impl PgReplicationConnection {
             match r {
                 1 => break,
                 0 => {
-                    // Would block: drain libpq's output buffer with PQflush before retrying. Just waiting for writability without flushing would spin — the socket stays writable while the buffer is never emptied, and PQputCopyEnd keeps returning 0.
-                    let flush = unsafe { PQflush(self.conn) };
-                    if flush < 0 {
-                        let msg = self.last_error_message();
-                        return Err(ReplicationError::protocol(format!("PQflush failed: {msg}")));
-                    }
-                    if flush == 1 {
-                        let async_fd = self.async_fd.as_ref().ok_or_else(|| {
-                            ReplicationError::protocol("AsyncFd not initialized".to_string())
-                        })?;
-                        let mut guard = async_fd.writable().await.map_err(|e| {
-                            ReplicationError::protocol(format!("wait writable failed: {e}"))
-                        })?;
-                        guard.clear_ready();
+                    // Would block: fully drain libpq's output buffer (loop PQflush until it returns 0) before retrying PQputCopyEnd — matching the flush loop in `put_copy_data_and_flush`. Flushing only once then retrying PQputCopyEnd wastes an FFI round-trip per partial flush; not flushing at all would spin (the socket stays writable while the buffer is never emptied).
+                    loop {
+                        let flush = unsafe { PQflush(self.conn) };
+                        match flush {
+                            0 => break,
+                            1 => {
+                                let async_fd = self.async_fd.as_ref().ok_or_else(|| {
+                                    ReplicationError::protocol(
+                                        "AsyncFd not initialized".to_string(),
+                                    )
+                                })?;
+                                let mut guard = async_fd.writable().await.map_err(|e| {
+                                    ReplicationError::protocol(format!("wait writable failed: {e}"))
+                                })?;
+                                guard.clear_ready();
+                            }
+                            _ => {
+                                let msg = self.last_error_message();
+                                return Err(ReplicationError::protocol(format!(
+                                    "PQflush failed: {msg}"
+                                )));
+                            }
+                        }
                     }
                 }
                 _ => {

--- a/src/connection/libpq.rs
+++ b/src/connection/libpq.rs
@@ -318,10 +318,9 @@ impl PgReplicationConnection {
         debug!("Starting replication: {}", sql);
         let _result = self.exec(&sql)?;
 
-        self.is_replication_conn = true;
-
-        // Initialize async socket for non-blocking operations
+        // Initialize the async socket first; mark the connection as being in replication mode only AFTER it succeeds, preserving the invariant `is_replication_conn == true ⇒ async_fd is Some`. Otherwise a failed socket setup would leave the flag true with no async_fd, and a later `end_copy`/Drop would reach the writable-wait path with `async_fd == None`.
         self.initialize_async_socket()?;
+        self.is_replication_conn = true;
 
         debug!("Replication started successfully");
         Ok(())
@@ -810,8 +809,8 @@ impl PgReplicationConnection {
         debug!("Starting physical replication: {}", sql);
         let _result = self.exec(&sql)?;
 
-        self.is_replication_conn = true;
         self.initialize_async_socket()?;
+        self.is_replication_conn = true;
 
         debug!("Physical replication started successfully");
         Ok(())
@@ -851,8 +850,8 @@ impl PgReplicationConnection {
         debug!("Starting base backup: {}", base_backup_sql);
         let result = self.exec(&base_backup_sql)?;
 
-        self.is_replication_conn = true;
         self.initialize_async_socket()?;
+        self.is_replication_conn = true;
 
         debug!("Base backup started successfully");
         Ok(result)

--- a/src/connection/native/connection.rs
+++ b/src/connection/native/connection.rs
@@ -707,6 +707,47 @@ impl NativeConnection {
         Ok(())
     }
 
+    /// Send a client CopyDone to end the COPY stream cleanly.
+    ///
+    /// Idempotent: a no-op when not in COPY mode. On the Inline driver we write
+    /// the CopyDone frame directly on the transport. On the Threaded driver we
+    /// hand the existing graceful `Close` command to the worker (which sends
+    /// CopyDone + Terminate) without blocking the async task on its reply —
+    /// `Drop`'s `close_connection` still joins the worker, guaranteeing the
+    /// frames flush before teardown completes.
+    pub(crate) async fn end_copy(&mut self) -> Result<()> {
+        if !self.in_copy_mode {
+            return Ok(());
+        }
+        // Mark the copy ended up front: if the Inline `send_copy_done` below errors out, this keeps `close_connection` on drop from redundantly re-sending CopyDone on an already-half-closed connection.
+        self.in_copy_mode = false;
+        match &mut self.driver {
+            Driver::Inline { worker, .. } => {
+                copy::send_copy_done(&mut worker.transport).await?;
+            }
+            Driver::Threaded {
+                cmd_tx, batch_rx, ..
+            } => {
+                // Dropping the batch receiver lets a back-pressured worker
+                // (parked on `reserve()`) resolve and service the command.
+                *batch_rx = None;
+                let (reply_tx, reply_rx) = std_mpsc::channel();
+                if cmd_tx
+                    .send(Command::Close {
+                        in_copy_mode: true,
+                        reply: reply_tx,
+                    })
+                    .is_ok()
+                {
+                    // The blocking `recv()` runs on a blocking thread so the async executor is not parked. `.is_ok()` above already handled a dead worker (channel closed), so this cannot hang on one.
+                    let _ = tokio::task::spawn_blocking(move || reply_rx.recv()).await;
+                }
+                self.alive.store(false, Ordering::Relaxed);
+            }
+        }
+        Ok(())
+    }
+
     /// Send hot standby feedback message to the server.
     pub async fn send_hot_standby_feedback(
         &mut self,
@@ -1821,5 +1862,25 @@ mod tests {
             Ok(Err(ReplicationError::Cancelled(_))) => {}
             other => panic!("expected a Cancelled error, got {other:?}"),
         }
+    }
+
+    #[tokio::test]
+    async fn end_copy_noop_when_not_in_copy_mode() {
+        // A null connection is not in COPY mode; end_copy must be a safe no-op.
+        let mut conn = NativeConnection::null_for_testing();
+        assert!(conn.end_copy().await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn end_copy_in_copy_mode_fires_close() {
+        // Force COPY mode so end_copy takes the live Threaded branch (drop
+        // batch_rx + fire Command::Close), not just the no-op guard. The null
+        // worker's socket is closed, so the CopyDone/Terminate best-effort I/O
+        // fails silently and the worker exits — end_copy still returns Ok.
+        let mut conn = NativeConnection::null_for_testing();
+        conn.in_copy_mode = true;
+        assert!(conn.end_copy().await.is_ok());
+        // Flag cleared → a second call takes the no-op guard path.
+        assert!(conn.end_copy().await.is_ok());
     }
 }

--- a/src/connection/native/connection.rs
+++ b/src/connection/native/connection.rs
@@ -719,15 +719,21 @@ impl NativeConnection {
         if !self.in_copy_mode {
             return Ok(());
         }
-        // Mark the copy ended up front: if the Inline `send_copy_done` below errors out, this keeps `close_connection` on drop from redundantly re-sending CopyDone on an already-half-closed connection.
-        self.in_copy_mode = false;
         match &mut self.driver {
             Driver::Inline { worker, .. } => {
-                copy::send_copy_done(&mut worker.transport).await?;
+                // Write the CopyDone, then mark the copy ended ONLY after it is fully flushed. If this errors or the future is cancelled mid-write, `in_copy_mode` stays true so Drop's `close(true)` resends a well-formed CopyDone rather than leaving a torn frame.
+                if let Err(e) = copy::send_copy_done(&mut worker.transport).await {
+                    self.alive.store(false, Ordering::Relaxed);
+                    return Err(e);
+                }
+                self.in_copy_mode = false;
             }
             Driver::Threaded {
                 cmd_tx, batch_rx, ..
             } => {
+                // The worker (not this task) writes the frame, so clearing the
+                // flag up front is safe and keeps Drop from re-sending CopyDone.
+                self.in_copy_mode = false;
                 // Dropping the batch receiver lets a back-pressured worker
                 // (parked on `reserve()`) resolve and service the command.
                 *batch_rx = None;

--- a/src/error.rs
+++ b/src/error.rs
@@ -4,6 +4,7 @@
 //! operations, connection handling, and message parsing.
 
 use crate::prelude::*;
+use crate::types::Lsn;
 
 /// Comprehensive error types for replication operations
 #[derive(Debug)]
@@ -56,6 +57,9 @@ pub enum ReplicationError {
     /// be spawned, exited early, or dropped a reply. Transient so the stream
     /// retry logic can reconnect.
     Backend(String),
+
+    /// Bounded replay reached its configured `stop_at_lsn`. Carries the commit end LSN at which streaming stopped. This is a clean, expected terminal signal (treated like a graceful end of stream), never retried.
+    StreamStopped(Lsn),
 }
 
 impl core::fmt::Display for ReplicationError {
@@ -78,6 +82,9 @@ impl core::fmt::Display for ReplicationError {
             Self::Generic(msg) => write!(f, "Replication error: {msg}"),
             Self::Deserialize(msg) => write!(f, "Deserialization error: {msg}"),
             Self::Backend(msg) => write!(f, "Backend worker error: {msg}"),
+            Self::StreamStopped(lsn) => {
+                write!(f, "Replication stopped at stop_at_lsn (reached {lsn})")
+            }
         }
     }
 }
@@ -185,6 +192,16 @@ impl ReplicationError {
         ReplicationError::Backend(msg.into())
     }
 
+    /// Create a bounded-replay terminal stop signal at the given LSN.
+    ///
+    /// Crate-internal: the library emits this; external consumers match the [`ReplicationError::StreamStopped`] variant rather than constructing it.
+    ///
+    /// Gated on a connection backend: the streaming layer that emits it  (`crate::stream`) is compiled only with `libpq`/`rustls-tls`, so this helper is dead code in the parser-only `no_std` build without the gate.
+    #[cfg(feature = "std")]
+    pub(crate) fn stream_stopped(lsn: Lsn) -> Self {
+        ReplicationError::StreamStopped(lsn)
+    }
+
     /// Check if the error is transient (can be retried)
     pub fn is_transient(&self) -> bool {
         #[cfg(feature = "std")]
@@ -213,6 +230,14 @@ impl ReplicationError {
     /// Check if the error is due to cancellation
     pub fn is_cancelled(&self) -> bool {
         matches!(self, ReplicationError::Cancelled(_))
+    }
+
+    /// Check if the error is the terminal bounded-replay stop signal.
+    ///
+    /// Gated on a connection backend for the same reason as [`Self::stream_stopped`]: its only caller lives in the backend-gated `crate::stream`.
+    #[cfg(feature = "std")]
+    pub(crate) fn is_stream_stopped(&self) -> bool {
+        matches!(self, ReplicationError::StreamStopped(_))
     }
 }
 
@@ -504,5 +529,36 @@ mod tests {
         assert!(err.is_transient());
         assert!(!err.is_permanent());
         assert!(!err.is_cancelled());
+    }
+}
+
+#[cfg(all(test, any(feature = "libpq", feature = "rustls-tls")))]
+mod stop_signal_tests {
+    use super::*;
+    use crate::types::Lsn;
+
+    #[test]
+    fn stream_stopped_is_terminal_not_retryable() {
+        let e = ReplicationError::stream_stopped(Lsn::new(0x1A2B));
+        assert!(e.is_stream_stopped(), "should report as stream-stopped");
+        assert!(!e.is_transient(), "stop signal must never be retried");
+        assert!(
+            !e.is_permanent(),
+            "stop signal is a graceful terminal, not a permanent error"
+        );
+        assert!(
+            !e.is_cancelled(),
+            "stop signal is distinct from cancellation"
+        );
+    }
+
+    #[test]
+    fn stream_stopped_displays_reached_lsn() {
+        let e = ReplicationError::StreamStopped(Lsn::new(0x100));
+        let s = format!("{e}");
+        assert!(
+            s.contains("stop"),
+            "message should mention stopping, got: {s}"
+        );
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -46,6 +46,10 @@ pub struct LogicalReplicationStream {
     exported_snapshot_name: Option<String>,
     /// Counter that throttles per-event time checks inside `next_event`. We only consult `Instant::now()` once every `FEEDBACK_CHECK_EVENT_INTERVAL` events so the hot path avoids a syscall on every message.
     feedback_check_counter: u32,
+    /// Bounded replay: set to the crossing commit's `end_lsn` once that event has been delivered; the next `next_event` sends CopyDone and returns `StreamStopped`. `None` when bounded replay is off or not yet reached.
+    stop_at_reached: Option<Lsn>,
+    /// One-shot guard so the bounded-replay CopyDone is sent at most once.
+    copy_done_sent: bool,
 }
 
 /// How often `next_event` consults `Instant::now()` to decide whether to send
@@ -75,6 +79,8 @@ pub struct ReplicationStreamConfig {
     pub retry_config: RetryConfig,
     pub slot_options: ReplicationSlotOptions,
     pub slot_type: SlotType,
+    /// Bounded replay: stop after the transaction whose commit `end_lsn` reaches this LSN. `None` (the default) streams unbounded.
+    pub stop_at_lsn: Option<Lsn>,
 }
 
 /// Streaming mode for logical replication (pgoutput)
@@ -181,6 +187,7 @@ impl ReplicationStreamConfig {
                 ..Default::default()
             },
             slot_type: SlotType::Logical,
+            stop_at_lsn: None,
         }
     }
 
@@ -284,6 +291,7 @@ impl Default for ReplicationStreamConfig {
                 ..Default::default()
             },
             slot_type: SlotType::Logical,
+            stop_at_lsn: None,
         }
     }
 }
@@ -334,6 +342,32 @@ impl ReplicationStreamConfig {
         self.retry_config = r;
         self
     }
+
+    /// Stop replication after the first committed transaction whose commit `end_lsn` reaches `lsn`. That transaction is delivered in full, then the stream ends cleanly (client CopyDone) and `next_event` returns [`crate::ReplicationError::StreamStopped`]. `None` (default) is unbounded.
+    #[inline]
+    pub fn with_stop_at_lsn(mut self, lsn: impl Into<Lsn>) -> Self {
+        self.stop_at_lsn = Some(lsn.into());
+        self
+    }
+}
+
+/// Bounded replay: given the configured `stop_at`, return `Some(end_lsn)` when
+/// `event` is a committed-transaction boundary (`Commit` / `StreamCommit` /
+/// `CommitPrepared`) whose `end_lsn` reaches the target, else `None`.
+///
+/// Pure and allocation-free. The `stop_at?` short-circuits with zero cost when
+/// bounded replay is off, and the match only ever fires on commit boundaries,
+/// so the DML hot path is untouched.
+#[inline]
+fn reached_stop_lsn(stop_at: Option<Lsn>, event: &ChangeEvent) -> Option<Lsn> {
+    let target = stop_at?;
+    let end_lsn = match &event.event_type {
+        EventType::Commit { end_lsn, .. }
+        | EventType::StreamCommit { end_lsn, .. }
+        | EventType::CommitPrepared { end_lsn, .. } => *end_lsn,
+        _ => return None,
+    };
+    (end_lsn >= target).then_some(end_lsn)
 }
 
 impl LogicalReplicationStream {
@@ -424,6 +458,8 @@ impl LogicalReplicationStream {
             shared_lsn_feedback,
             exported_snapshot_name: None,
             feedback_check_counter: 0,
+            stop_at_reached: None,
+            copy_done_sent: false,
         })
     }
 
@@ -652,6 +688,20 @@ impl LogicalReplicationStream {
                 ));
             }
 
+            // Bounded replay terminal: once a stop boundary has been delivered,
+            // end the COPY stream cleanly (once) and report StreamStopped on
+            // this and every subsequent call. Runs before any socket read so no
+            // further WAL is consumed past the target.
+            if let Some(reached) = self.stop_at_reached {
+                if !self.copy_done_sent {
+                    self.copy_done_sent = true;
+                    if let Err(e) = self.connection.end_copy().await {
+                        warn!("Failed to send CopyDone at stop_at_lsn: {e}");
+                    }
+                }
+                return Err(ReplicationError::stream_stopped(reached));
+            }
+
             // Throttle feedback checks: only consult `Instant::now()` and the shared atomic once every FEEDBACK_CHECK_EVENT_INTERVAL iterations, feedback is time-based (10s default), so skipping up to ~511 checks does not delay it perceptibly while removing a per-event syscall.
             self.feedback_check_counter = self.feedback_check_counter.wrapping_add(1);
             if self.feedback_check_counter & (FEEDBACK_CHECK_EVENT_INTERVAL - 1) == 0 {
@@ -672,6 +722,13 @@ impl LogicalReplicationStream {
                 b'w' => {
                     // WAL data message (zero-copy: Bytes slicing avoids copies)
                     if let Some(event) = self.process_wal_message(data)? {
+                        // Bounded replay: if this event is a commit boundary that
+                        // reaches stop_at_lsn, remember it — the full crossing
+                        // transaction is still delivered now; the NEXT call
+                        // terminates.
+                        if let Some(reached) = reached_stop_lsn(self.config.stop_at_lsn, &event) {
+                            self.stop_at_reached = Some(reached);
+                        }
                         return Ok(event);
                     }
                 }
@@ -835,9 +892,12 @@ impl LogicalReplicationStream {
             match self.next_event(cancellation_token).await {
                 Ok(event) => return Ok(event),
                 Err(e) => {
-                    // Check if it's a cancellation error - these should not be retried
-                    if matches!(e, ReplicationError::Cancelled(_)) {
-                        error!("Operation cancelled: {}", e);
+                    // Cancellation and bounded-replay stop are terminal — never retry.
+                    if matches!(
+                        e,
+                        ReplicationError::Cancelled(_) | ReplicationError::StreamStopped(_)
+                    ) {
+                        debug!("Terminal signal, ending stream: {}", e);
                         return Err(e);
                     }
 
@@ -1909,7 +1969,9 @@ where
                 handler(ev).await?;
                 source.ack(lsn);
             }
-            Err(ReplicationError::Cancelled(_)) => return Ok(()),
+            Err(ReplicationError::Cancelled(_)) | Err(ReplicationError::StreamStopped(_)) => {
+                return Ok(())
+            }
             Err(e) => return Err(e),
         }
     }
@@ -2076,7 +2138,7 @@ impl futures_core::Stream for EventStream {
 
                 match result {
                     Ok(event) => std::task::Poll::Ready(Some(Ok(event))),
-                    Err(ref e) if e.is_cancelled() => {
+                    Err(ref e) if e.is_cancelled() || e.is_stream_stopped() => {
                         self.terminated = true;
                         std::task::Poll::Ready(None)
                     }
@@ -2194,6 +2256,96 @@ async fn timeout_or_error<T>(
         Err(_) => Err(ReplicationError::timeout(format!(
             "Connection attempt exceeded timeout of {duration:?}"
         ))),
+    }
+}
+
+#[cfg(test)]
+mod reached_stop_lsn_tests {
+    use super::*;
+    use crate::column_value::{ColumnValue, RowData};
+
+    fn ts() -> chrono::DateTime<chrono::Utc> {
+        chrono::DateTime::<chrono::Utc>::from_timestamp(0, 0).unwrap()
+    }
+    fn commit(end: u64) -> ChangeEvent {
+        ChangeEvent {
+            event_type: EventType::Commit {
+                commit_timestamp: ts(),
+                commit_lsn: Lsn::new(end),
+                end_lsn: Lsn::new(end),
+            },
+            lsn: Lsn::new(end),
+            metadata: None,
+        }
+    }
+    fn stream_commit(end: u64) -> ChangeEvent {
+        ChangeEvent {
+            event_type: EventType::StreamCommit {
+                transaction_id: 7,
+                commit_lsn: Lsn::new(end),
+                end_lsn: Lsn::new(end),
+                commit_timestamp: ts(),
+            },
+            lsn: Lsn::new(end),
+            metadata: None,
+        }
+    }
+    fn commit_prepared(end: u64) -> ChangeEvent {
+        ChangeEvent {
+            event_type: EventType::CommitPrepared {
+                flags: 0,
+                transaction_id: 7,
+                commit_lsn: Lsn::new(end),
+                end_lsn: Lsn::new(end),
+                commit_timestamp: ts(),
+                gid: std::sync::Arc::from("g"),
+            },
+            lsn: Lsn::new(end),
+            metadata: None,
+        }
+    }
+    fn insert(lsn: u64) -> ChangeEvent {
+        let data = RowData::from_pairs(vec![("id", ColumnValue::text("1"))]);
+        ChangeEvent::insert("public", "t", 1, data, Lsn::new(lsn))
+    }
+
+    #[test]
+    fn none_when_feature_off() {
+        assert_eq!(reached_stop_lsn(None, &commit(9999)), None);
+    }
+
+    #[test]
+    fn stops_at_or_after_target_on_commit() {
+        assert_eq!(reached_stop_lsn(Some(Lsn::new(100)), &commit(99)), None);
+        assert_eq!(
+            reached_stop_lsn(Some(Lsn::new(100)), &commit(100)),
+            Some(Lsn::new(100))
+        );
+        assert_eq!(
+            reached_stop_lsn(Some(Lsn::new(100)), &commit(101)),
+            Some(Lsn::new(101))
+        );
+    }
+
+    #[test]
+    fn handles_stream_commit_and_commit_prepared() {
+        assert_eq!(
+            reached_stop_lsn(Some(Lsn::new(50)), &stream_commit(50)),
+            Some(Lsn::new(50))
+        );
+        assert_eq!(
+            reached_stop_lsn(Some(Lsn::new(50)), &commit_prepared(60)),
+            Some(Lsn::new(60))
+        );
+        assert_eq!(
+            reached_stop_lsn(Some(Lsn::new(50)), &stream_commit(49)),
+            None
+        );
+    }
+
+    #[test]
+    fn never_stops_on_non_commit_events() {
+        assert_eq!(reached_stop_lsn(Some(Lsn::new(1)), &insert(9999)), None);
     }
 }
 
@@ -4079,7 +4231,63 @@ mod tests {
             shared_lsn_feedback: SharedLsnFeedback::new_shared(),
             exported_snapshot_name: None,
             feedback_check_counter: 0,
+            stop_at_reached: None,
+            copy_done_sent: false,
         }
+    }
+
+    #[tokio::test]
+    async fn next_event_terminates_after_stop_boundary_reached() {
+        // Simulate a crossing commit already delivered: the terminal guard must
+        // send CopyDone once (a no-op on the null test connection) and return
+        // StreamStopped on this and every subsequent call, without reading WAL.
+        let cfg = ReplicationStreamConfig::builder("slot", "pub").with_stop_at_lsn(0x100u64);
+        let mut stream = create_test_stream(cfg);
+        stream.stop_at_reached = Some(Lsn::new(0x100));
+        let token = CancellationToken::new();
+
+        let err = stream.next_event(&token).await.unwrap_err();
+        assert!(
+            matches!(err, ReplicationError::StreamStopped(l) if l == Lsn::new(0x100)),
+            "expected StreamStopped(0x100), got {err:?}"
+        );
+        assert!(
+            stream.copy_done_sent,
+            "CopyDone must be sent once on termination"
+        );
+
+        // Idempotent: a second call still reports StreamStopped without resending.
+        let err2 = stream.next_event(&token).await.unwrap_err();
+        assert!(matches!(err2, ReplicationError::StreamStopped(_)));
+    }
+
+    #[tokio::test]
+    async fn next_event_with_retry_passes_through_stream_stopped() {
+        // StreamStopped is terminal — returned immediately, never retried.
+        let cfg = ReplicationStreamConfig::builder("slot", "pub").with_stop_at_lsn(0x200u64);
+        let mut stream = create_test_stream(cfg);
+        stream.stop_at_reached = Some(Lsn::new(0x200));
+        let token = CancellationToken::new();
+
+        let err = stream.next_event_with_retry(&token).await.unwrap_err();
+        assert!(
+            matches!(err, ReplicationError::StreamStopped(l) if l == Lsn::new(0x200)),
+            "retry wrapper must pass StreamStopped through unretried, got {err:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn event_stream_terminates_none_on_stream_stopped() {
+        use futures::StreamExt;
+        // poll_next maps StreamStopped to a graceful end-of-stream (None + terminated).
+        let cfg = ReplicationStreamConfig::builder("slot", "pub").with_stop_at_lsn(0x300u64);
+        let mut stream = create_test_stream(cfg);
+        stream.stop_at_reached = Some(Lsn::new(0x300));
+        let token = CancellationToken::new();
+        let mut es = stream.into_stream(token);
+
+        assert!(es.next().await.is_none(), "StreamStopped should yield None");
+        assert!(es.is_terminated(), "stream should mark itself terminated");
     }
 
     #[test]
@@ -8388,5 +8596,42 @@ mod for_each_event_tests {
         let mut src = MockSource::new(vec![Err(ReplicationError::deserialize("io"))]);
         let out = for_each_event_impl(&mut src, |_ev| async { Ok(()) }).await;
         assert!(out.is_err());
+    }
+
+    #[tokio::test]
+    async fn for_each_event_stops_gracefully_on_stream_stopped() {
+        let mut src = MockSource::new(vec![
+            Ok(ins(10)),
+            Ok(ins(20)),
+            Err(ReplicationError::stream_stopped(Lsn::new(25))),
+        ]);
+        let mut count = 0u32;
+        let res = for_each_event_impl(&mut src, |_ev| {
+            count += 1;
+            async { Ok(()) }
+        })
+        .await;
+        assert!(res.is_ok(), "StreamStopped must end the loop gracefully");
+        assert_eq!(count, 2, "both events before the stop are handled");
+        assert_eq!(src.last_ack.load(std::sync::atomic::Ordering::SeqCst), 20);
+    }
+}
+
+#[cfg(test)]
+mod stop_at_lsn_config_tests {
+    use super::*;
+
+    #[test]
+    fn default_config_has_no_stop_lsn() {
+        let cfg = ReplicationStreamConfig::default();
+        assert_eq!(cfg.stop_at_lsn, None);
+        let cfg2 = ReplicationStreamConfig::builder("slot", "pub");
+        assert_eq!(cfg2.stop_at_lsn, None);
+    }
+
+    #[test]
+    fn with_stop_at_lsn_sets_target() {
+        let cfg = ReplicationStreamConfig::builder("slot", "pub").with_stop_at_lsn(0x2000u64);
+        assert_eq!(cfg.stop_at_lsn, Some(Lsn::new(0x2000)));
     }
 }

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -872,6 +872,15 @@ impl LogicalReplicationStream {
         &mut self,
         cancellation_token: &CancellationToken,
     ) -> Result<ChangeEvent> {
+        // Bounded-replay terminal is authoritative: once a stop boundary has been
+        // reached, delegate straight to `next_event` (which sends CopyDone once and
+        // returns StreamStopped) and skip the health check below. Otherwise a dead
+        // connection could be reconnected by `recover_connection` and the COPY
+        // stream resurrected past `stop_at_lsn`.
+        if self.stop_at_reached.is_some() {
+            return self.next_event(cancellation_token).await;
+        }
+
         // Perform periodic health check.
         //
         // The check itself is cheap when nothing is wrong (it just compares `Instant::now()` against `last_health_check`), but `Instant::now()` is a vDSO syscall on Linux. At 100k+ rps that adds up, so we gate the health check on the per-event feedback counter and let it amortize across `HEALTH_CHECK_EVENT_INTERVAL` events. The actual time-based interval inside `check_connection_health()` still applies, this just skips the syscall on the inner-loop hot path.


### PR DESCRIPTION
- add reached_stop_lsn commit-boundary helper
- add end_copy() to send client CopyDone on both backends
- map StreamStopped to graceful end in for_each/retry/Stream
- terminate next_event at stop_at_lsn with clean CopyDone