### PR TITLE
slot-error classification, reconnect fixes, UPLOAD_MANIFEST

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -3,11 +3,11 @@
 ## Build & Test Commands
 
 ```bash
-# Build (default libpq backend)
+# Build (default: pure-Rust rustls-tls backend)
 cargo build
 
-# Build (pure-Rust rustls-tls backend)
-cargo build --no-default-features --features rustls-tls
+# Build (opt-in libpq FFI backend)
+cargo build --no-default-features --features libpq
 
 # Run unit tests (no PostgreSQL required)
 cargo test --lib
@@ -48,8 +48,8 @@ src/
 ├── retry.rs         # Exponential backoff retry logic
 └── connection/      # PostgreSQL connection backends
     ├── mod.rs
-    ├── libpq.rs     # libpq FFI backend (default)
-    └── native/      # Pure-Rust rustls-tls backend
+    ├── libpq.rs     # libpq FFI backend (opt-in)
+    └── native/      # Pure-Rust rustls-tls backend (default)
 
 macros/              # pg-walstream-macros proc-macro crate (opt-in `derive` feature)
 └── src/lib.rs       #   #[derive(WalTable)] → impl WalTable { const TABLE }

--- a/.github/workflows/ci-checks.yml
+++ b/.github/workflows/ci-checks.yml
@@ -227,6 +227,10 @@ jobs:
         psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET max_prepared_transactions = 16;"
         # streaming_decode forces protocol-v2 streaming by keeping the reorder buffer tiny.
         psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET logical_decoding_work_mem = '64kB';"
+        # upload_manifest's incremental BASE_BACKUP needs WAL summaries. The GUC is PG17+;
+        # on 15/16 this fails and the test skips itself.
+        psql -h localhost -U postgres -d test_walstream -c "ALTER SYSTEM SET summarize_wal = 'on';" \
+          || echo "summarize_wal unsupported (PG<17) - the incremental backup test will skip"
         # Restart PostgreSQL container to apply wal_level change (requires restart)
         docker restart ${{ job.services.postgres.id }}
         # Wait for PostgreSQL to be ready after restart
@@ -244,100 +248,83 @@ jobs:
         psql -h localhost -U postgres -d test_walstream -c "SHOW max_replication_slots;"
         psql -h localhost -U postgres -d test_walstream -c "SHOW max_wal_senders;"
 
+    # A real backup_manifest for the incremental BASE_BACKUP test. Taken inside the
+    # container so the local trust rule applies: the image's pg_hba.conf has no
+    # `host replication` entry for the runner's address, and pg_basebackup opens a
+    # physical replication connection (unlike the logical `replication=database`
+    # connections every other test uses, which match on database name instead).
+    - name: Prepare a backup manifest (PG17+)
+      env:
+        PGPASSWORD: postgres
+      run: |
+        VER=$(psql -h localhost -U postgres -d test_walstream -tAc "SHOW server_version_num")
+        if [ "$VER" -ge 170000 ]; then
+          docker exec ${{ job.services.postgres.id }} rm -rf /tmp/bb
+          docker exec -u postgres ${{ job.services.postgres.id }} \
+            pg_basebackup -D /tmp/bb -Fp -X stream --no-sync
+          docker cp ${{ job.services.postgres.id }}:/tmp/bb/backup_manifest ./backup_manifest
+          echo "BACKUP_MANIFEST_PATH=$PWD/backup_manifest" >> $GITHUB_ENV
+          echo "prepared a backup manifest for PG $VER"
+        else
+          echo "PG $VER < 17: UPLOAD_MANIFEST does not exist, the test will skip"
+        fi
+
     - name: Run integration tests
       env:
         DATABASE_URL: "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
         DATABASE_URL_REGULAR: "postgresql://postgres:postgres@localhost:5432/test_walstream"
+        PGPASSWORD: postgres
         RUST_BACKTRACE: 1
+      # The suite list comes from the filesystem, so a new integration-tests/*.rs
+      # runs automatically, and one that is missing its `[[test]]` target in
+      # Cargo.toml fails here ("no test target named ...") instead of being
+      # silently skipped. Only the exceptions need naming below; every other
+      # suite runs once on default features. Each suite's purpose is documented
+      # in its own `//!` header rather than duplicated here.
       run: |
-        cargo test --test snapshot_export -- --ignored --nocapture --test-threads=1
+        set -uo pipefail
+        failed=()
 
-        # Clean up any lingering replication slots between test suites
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+        for f in integration-tests/*.rs; do
+          suite=$(basename "$f" .rs)
 
-        cargo test --test rate_limited_streaming -- --ignored --nocapture --test-threads=1
+          case "$suite" in
+            # `ssl_*` suites belong to the integration-ssl job below, which has a
+            # TLS-configured server and generated certificates. The two jobs
+            # partition integration-tests/ on this prefix, so every file lands in
+            # exactly one of them.
+            ssl_*) continue ;;
+            # Exercise the opt-in derive-macro layer.
+            typed_deserialization|ergonomics) variants=("--features derive") ;;
+            # libpq-only API surface.
+            pg_result_get_bytes) variants=("--no-default-features --features libpq") ;;
+            # Server diagnostics and COPY framing are parsed independently by each
+            # backend, so these must prove out on both.
+            error_classification|upload_manifest)
+              variants=("" "--no-default-features --features libpq") ;;
+            *) variants=("") ;;
+          esac
 
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+          for v in "${variants[@]}"; do
+            label="$suite${v:+ [$v]}"
+            echo "::group::$label"
+            cargo test --test "$suite" $v -- --ignored --nocapture --test-threads=1 \
+              || failed+=("$label")
+            echo "::endgroup::"
+            # Drop every slot between suites: an orphan blocks WAL recycling and
+            # can exhaust the server's disk.
+            psql -h localhost -U postgres -d test_walstream \
+              -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots;" \
+              >/dev/null 2>&1 || true
+          done
+        done
 
-        cargo test --test safe_transaction_consumer -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        cargo test --test complex_types -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        cargo test --test typed_deserialization --features derive -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        cargo test --test pgoutput_fidelity -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        cargo test --test streaming_decode -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        cargo test --test binary_columns -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        cargo test --test pg_result_get_bytes --no-default-features --features libpq -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        # Ergonomics layer (WalRouter, for_each_event) + derive layer (WalTable /
-        # on_*_of) — the derive module is #[cfg(feature = "derive")].
-        cargo test --test ergonomics --features derive -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        # Bounded replay: stream to a target LSN, stop cleanly at the commit boundary.
-        cargo test --test bounded_replay -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        # Raw XLogData bytes API: round-trip raw pgoutput through the parser, stop at target LSN.
-        cargo test --test raw_xlogdata -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        # FAILOVER slot creation (issue #103): parenthesized option grammar, skips gracefully on PG<17; verifies pg_replication_slots.failover on 17/18.
-        cargo test --test failover_slot -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        # CREATE_REPLICATION_SLOT option matrix: every emitted option combination executed against the live server, version-gated (issue #103).
-        cargo test --test slot_matrix -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots;" || true
-
-        # BASE_BACKUP option combination: asserts the server accepts every generated option name (PG15+), then aborts the backup without draining.
-        cargo test --test base_backup_options -- --ignored --nocapture --test-threads=1
-
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
-
-        # Server-version preflight: end-to-end core CDC path (create slot -> stream -> decode INSERT) plus PG17+ gated slot ops (FAILOVER create + ALTER) that must pass the client-side version gate and execute; the gated portion skips gracefully on PG<17.
-        cargo test --test version_preflight -- --ignored --nocapture --test-threads=1
-
-        # quote_literal escaping: proves quote_literal stays injection-safe under standard_conforming_strings off and on (a backslash+quote payload roundtrips byte-for-byte); uses the regular connection and creates no replication slot.
-        cargo test --test quote_literal_scs_off -- --ignored --nocapture --test-threads=1
+        if [ ${#failed[@]} -gt 0 ]; then
+          printf '::error::%d integration suite(s) failed:\n' "${#failed[@]}"
+          printf '  - %s\n' "${failed[@]}"
+          exit 1
+        fi
+        echo "All integration suites passed."
 
   integration-ssl:
     name: SSL Integration Tests (PG ${{ matrix.pg_version }})
@@ -485,8 +472,17 @@ jobs:
         PGSSLMODE=require psql -h localhost -U postgres -d test_walstream \
           -c "SELECT ssl, version FROM pg_stat_ssl WHERE pid = pg_backend_pid();"
 
-    - name: Build SSL test binary
-      run: cargo test --test ssl_connections --no-default-features --features rustls-tls --no-run
+    # Compile first so a build break is reported before the server setup above is
+    # blamed for it. SSL is a rustls-tls capability; the libpq backend delegates
+    # TLS to libpq and has nothing to exercise here.
+    - name: Build SSL test binaries
+      run: |
+        set -uo pipefail
+        shopt -s nullglob
+        for f in integration-tests/ssl_*.rs; do
+          cargo test --test "$(basename "$f" .rs)" \
+            --no-default-features --features rustls-tls --no-run
+        done
 
     - name: Run SSL integration tests
       env:
@@ -495,9 +491,37 @@ jobs:
         SSL_CA_CERT_PATH: "/tmp/pg-ssl/ca.crt"
         SSL_WRONG_CA_CERT_PATH: "/tmp/pg-ssl/wrong-ca.crt"
         RUST_BACKTRACE: 1
+      # Same filesystem enumeration as the integration job, over the `ssl_*`
+      # half of the partition: a new SSL suite is picked up automatically.
       run: |
-        cargo test --test ssl_connections --no-default-features --features rustls-tls -- --ignored --nocapture --test-threads=1
+        set -uo pipefail
+        shopt -s nullglob
+        failed=()
+        ran=0
 
-        # Clean up any lingering replication slots between runs
-        PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
-          -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots WHERE slot_type = 'logical';" || true
+        for f in integration-tests/ssl_*.rs; do
+          suite=$(basename "$f" .rs)
+          ran=$((ran + 1))
+          echo "::group::$suite"
+          cargo test --test "$suite" --no-default-features --features rustls-tls \
+            -- --ignored --nocapture --test-threads=1 || failed+=("$suite")
+          echo "::endgroup::"
+          # Drop every slot between suites: an orphan blocks WAL recycling.
+          PGPASSWORD=postgres psql -h localhost -U postgres -d test_walstream \
+            -c "SELECT pg_drop_replication_slot(slot_name) FROM pg_replication_slots;" \
+            >/dev/null 2>&1 || true
+        done
+
+        # Without this the job would pass silently if the suites were renamed out
+        # of the `ssl_*` prefix the integration job skips on.
+        if [ "$ran" -eq 0 ]; then
+          echo "::error::no integration-tests/ssl_*.rs found - SSL coverage would be silently skipped"
+          exit 1
+        fi
+
+        if [ ${#failed[@]} -gt 0 ]; then
+          printf '::error::%d SSL suite(s) failed:\n' "${#failed[@]}"
+          printf '  - %s\n' "${failed[@]}"
+          exit 1
+        fi
+        echo "All $ran SSL suite(s) passed." 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,9 @@ jobs:
     - name: Clippy no_std (alloc)
       run: cargo clippy --no-default-features --lib -- -D warnings
 
+    - name: Build lib tests without a backend
+      run: cargo test --lib --no-default-features --features std --no-run
+
   security:
     name: Security Audit
     runs-on: ubuntu-latest

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -55,9 +55,9 @@ checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.18.0"
+version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce2b2dcc879c3bae0d371e77c99f2238400ef24ec001394befa67b6e543add9e"
+checksum = "b281d307588d634de920874890732659e2e7672f72b5e10e81badc1a8a83621e"
 dependencies = [
  "aws-lc-sys",
  "untrusted 0.7.1",
@@ -66,9 +66,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.44.0"
+version = "0.45.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f09fae7be8bb3174e05c6afdb34199e6dc0c7c04ba9fa237b1967adfbde27483"
+checksum = "9bff6c3b54fad79a2e60b8102caf565819711497c1f5f092f49508e2f5c31b27"
 dependencies = [
  "cc",
  "cmake",
@@ -142,9 +142,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.4.0"
+version = "1.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5add81bb678e6cb321aff7fa0dc7689ad82b112dbc032cea19f91d6b8e3582b9"
+checksum = "0ad534f4357a5264cce5019c989cf66a4f0dc4e0d1b1d15f8aacec0ff7360273"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -449,9 +449,9 @@ checksum = "da7c62ceae207dd37ea5b845da6a0696c799f85e97da1ab5b7910be3c1c80223"
 
 [[package]]
 name = "find-msvc-tools"
-version = "0.1.9"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+checksum = "d45db016d36b838f563236e9193d0ee6ce38f3f68b6c94e914b4929c96bbb890"
 
 [[package]]
 name = "fnv"
@@ -521,7 +521,7 @@ checksum = "9fb9654ba8355388abeb8dcb4fc62f511300867002afc858860463bdd9fe0c44"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -729,9 +729,9 @@ dependencies = [
 
 [[package]]
 name = "log"
-version = "0.4.33"
+version = "0.4.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
+checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
 name = "md-5"
@@ -751,9 +751,9 @@ checksum = "cf8baf1c55e62ffcace7a9f06f4bd9cd3f0c4beb022d3b367256b91b87513d98"
 
 [[package]]
 name = "mio"
-version = "1.2.2"
+version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "30d65c71f1ce40ab09135ce117d742b9f8a19ff91a41a8b57ed50bc2de59c427"
+checksum = "4b18443e9c262bfe8fa82f51666e2642c53393f7e5c27b3e1aeab922cff5b9d8"
 dependencies = [
  "libc",
  "wasi",
@@ -831,7 +831,7 @@ version = "0.8.1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -871,9 +871,9 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"
-version = "0.3.33"
+version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+checksum = "f6b464fbc74e149a392436b17d523f769e057cb6877f6a5c4618bc6f11800548"
 
 [[package]]
 name = "plotters"
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.13"
+version = "0.103.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+checksum = "f3c3cf1d8b1e7d4927e2d154c3fcb02979afb9939629c62cd9048d4f07b60ac2"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1242,7 +1242,7 @@ checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
@@ -1302,9 +1302,9 @@ checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
 name = "smallvec"
-version = "1.15.2"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
+checksum = "b9be42f50aa861c555654aa3a37f52f4b1074bacf4e48fe0ef7fa584e80f1f0f"
 dependencies = [
  "serde",
 ]
@@ -1359,9 +1359,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "3.0.3"
+version = "3.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "53e9bae58849f64dfa4f5d5ae372c8341f7305f82a3868709269343628b659a3"
+checksum = "12df2e0110f65b775f769bb17ef989067a1d931b2eb822bd4346631eeada89f9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1375,7 +1375,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
  "windows-sys 0.61.2",
@@ -1440,14 +1440,14 @@ checksum = "78773a2a397f451582ce068015985c33193cf6dea8b74d2a639fe457b2f07b0e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 3.0.3",
+ "syn 3.0.5",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "b0c85f2c3ef0b1cd58b36682f4b17aaa995f0e5db534d85692b4903abce21f67"
 dependencies = [
  "rustls",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,18 +38,18 @@ bytes = { version = "1.12.1", default-features = false, features = ["serde"] }
 tracing = { version = "0.1.44", default-features = false }
 futures-core = { version = "0.3.34", default-features = false }
 memchr = { version = "2.8.3", default-features = false }
-smallvec = { version = "1.15.2", features = ["serde"] }
+smallvec = { version = "1.16.0", features = ["serde"] }
 pg-walstream-macros = { workspace = true, optional = true }
 
 # libpq backend (opt-in) — pq-sys: raw FFI to the system libpq via pkg-config, with pre-generated bindings (no libclang/bindgen at build time).
 pq-sys = { version = "0.7.5", optional = true }
 
 # rustls-tls
-tokio-rustls = { version = "0.26.4", optional = true }
+tokio-rustls = { version = "0.26.5", optional = true }
 rustls = { version = "0.23.43", default-features = false, features = ["std", "tls12"], optional = true }
 webpki-roots = { version = "1.0.9", optional = true }
 postgres-protocol = { version = "0.6.12", optional = true }
-aws-lc-rs = { version = "1.18.0", optional = true }
+aws-lc-rs = { version = "1.18.1", optional = true }
 socket2 = { version = "0.6.5", features = ["all"], optional = true }
 
 [features]
@@ -164,6 +164,18 @@ path = "integration-tests/version_preflight.rs"
 [[test]]
 name = "quote_literal_scs_off"
 path = "integration-tests/quote_literal_scs_off.rs"
+
+[[test]]
+name = "truncate_flags"
+path = "integration-tests/truncate_flags.rs"
+
+[[test]]
+name = "error_classification"
+path = "integration-tests/error_classification.rs"
+
+[[test]]
+name = "upload_manifest"
+path = "integration-tests/upload_manifest.rs"
 
 [[bench]]
 name = "wal_pipeline"

--- a/examples/rate-limited-streaming/src/main.rs
+++ b/examples/rate-limited-streaming/src/main.rs
@@ -187,8 +187,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                     EventType::Commit { commit_lsn, .. } => {
                         info!("COMMIT transaction at LSN {}", commit_lsn);
                     }
-                    EventType::Truncate(tables) => {
-                        warn!("TRUNCATE tables: {:?}", tables);
+                    EventType::Truncate {
+                        tables,
+                        cascade,
+                        restart_identity,
+                    } => {
+                        warn!(
+                            "TRUNCATE tables: {:?} (cascade={}, restart_identity={})",
+                            tables, cascade, restart_identity
+                        );
                     }
                     _ => {
                         info!("Event at LSN {}", event.lsn);

--- a/integration-tests/base_backup_options.rs
+++ b/integration-tests/base_backup_options.rs
@@ -14,10 +14,9 @@
 //!
 //! `build_base_backup_sql` emits the PostgreSQL 15+ parenthesized generic-option
 //! form, so this test is gated to `server_version_num >= 150000` and skips with a
-//! `warn!` on PostgreSQL 14. The `INCREMENTAL` option (PG17+) is intentionally NOT
-//! exercised here: an incremental backup requires a prior `UPLOAD_MANIFEST`
-//! handshake that this crate does not implement. `INCREMENTAL` is covered at the
-//! unit level (`build_base_backup_sql` golden test) instead.
+//! `warn!` on PostgreSQL 14. The `INCREMENTAL` option (PG17+) is not exercised
+//! here because it needs a prior `UPLOAD_MANIFEST` on the same connection; that
+//! pairing has its own test in `upload_manifest.rs`.
 //!
 //! ## Prerequisites
 //!
@@ -67,9 +66,9 @@ fn server_version_num(conn: &mut PgReplicationConnection) -> i64 {
         .expect("server_version_num is numeric")
 }
 
-#[test]
+#[tokio::test]
 #[ignore = "requires live PostgreSQL 15+"]
-fn test_base_backup_options_accepted() {
+async fn test_base_backup_options_accepted() {
     init_tracing();
 
     let mut regular =

--- a/integration-tests/error_classification.rs
+++ b/integration-tests/error_classification.rs
@@ -1,0 +1,179 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
+//! Integration test for SQLSTATE-based error classification.
+//!
+//! Both backends used to discard the server's SQLSTATE and return every failure
+//! as a generic `Protocol` error, so a dead replication slot was indistinguishable
+//! from a transient hiccup and consumers had to string-match an error message
+//! whose wording changed in PostgreSQL 18. `ReplicationError::from_sqlstate` now
+//! promotes the two slot-fatal codes to `ReplicationSlot`, which `is_permanent()`
+//! reports as `true` so the retry loop gives up instead of reconnecting into the
+//! same dead slot.
+//!
+//! Covered against a live server:
+//! - `42704` undefined_object — START_REPLICATION on a slot that does not exist.
+//! - `55000` object_not_in_prerequisite_state — logical replication started on
+//!   a physical slot (the same code slot invalidation raises).
+//! - a non-slot error stays retryable rather than being over-classified.
+//!
+//! ## Prerequisites
+//!
+//! - PostgreSQL with `wal_level = logical`
+//! - `DATABASE_URL` — replication connection
+//! - `DATABASE_URL_REGULAR` — regular connection to the same database
+//!
+//! ## Running Locally
+//!
+//! ```bash
+//! export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+//! export DATABASE_URL_REGULAR="postgresql://postgres:postgres@localhost:5432/test_walstream"
+//! cargo test --test error_classification -- --ignored --nocapture --test-threads=1
+//! ```
+
+use pg_walstream::{PgReplicationConnection, ReplicationError};
+
+fn replication_conn_string() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+            .to_string()
+    })
+}
+
+fn regular_conn_string() -> String {
+    std::env::var("DATABASE_URL_REGULAR").unwrap_or_else(|_| {
+        let repl = replication_conn_string();
+        repl.replace("?replication=database", "")
+            .replace("&replication=database", "")
+    })
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .try_init();
+}
+
+fn drop_slot(slot_name: &str) {
+    if let Ok(mut conn) = PgReplicationConnection::connect(&replication_conn_string()) {
+        let _ = conn.exec(&format!(
+            "SELECT pg_drop_replication_slot('{slot_name}') \
+             WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{slot_name}')"
+        ));
+    }
+}
+
+/// START_REPLICATION on a slot that was never created: the server answers
+/// SQLSTATE 42704, which must surface as a permanent `ReplicationSlot` error.
+#[test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+fn missing_slot_is_a_permanent_replication_slot_error() {
+    init_tracing();
+    let slot = "it_errcls_absent_slot";
+    drop_slot(slot);
+
+    let mut repl = PgReplicationConnection::connect(&replication_conn_string())
+        .expect("replication connection");
+
+    let err = repl
+        .start_replication(
+            slot,
+            0,
+            &[("proto_version", "2"), ("publication_names", "p")],
+        )
+        .expect_err("START_REPLICATION on an absent slot must fail");
+
+    assert!(
+        matches!(err, ReplicationError::ReplicationSlot(_)),
+        "expected ReplicationSlot, got {err:?}"
+    );
+    assert!(
+        err.is_permanent(),
+        "a missing slot must not be retried: {err}"
+    );
+    assert!(
+        err.to_string().contains("42704"),
+        "the SQLSTATE must reach the caller: {err}"
+    );
+}
+
+/// Starting *logical* replication on a *physical* slot yields SQLSTATE 55000 —
+/// the same object_not_in_prerequisite_state code slot invalidation uses, and
+/// the one that must stop the retry loop.
+///
+/// Invalidation itself (`wal_removed` / `rows_removed` / `idle_timeout`) needs
+/// minutes of WAL churn or server restarts to provoke; this reaches the same
+/// classification path deterministically and in milliseconds.
+#[test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+fn wrong_slot_type_is_a_permanent_replication_slot_error() {
+    init_tracing();
+    let slot = "it_errcls_physical_slot";
+    drop_slot(slot);
+
+    struct SlotGuard<'a>(&'a str);
+    impl Drop for SlotGuard<'_> {
+        fn drop(&mut self) {
+            drop_slot(self.0);
+        }
+    }
+    let _guard = SlotGuard(slot);
+
+    let mut regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    regular
+        .exec(&format!(
+            "SELECT pg_create_physical_replication_slot('{slot}')"
+        ))
+        .expect("create physical slot");
+
+    let mut repl = PgReplicationConnection::connect(&replication_conn_string())
+        .expect("replication connection");
+
+    let err = repl
+        .start_replication(
+            slot,
+            0,
+            &[("proto_version", "2"), ("publication_names", "p")],
+        )
+        .expect_err("logical replication on a physical slot must fail");
+
+    assert!(
+        matches!(err, ReplicationError::ReplicationSlot(_)),
+        "expected ReplicationSlot, got {err:?}"
+    );
+    assert!(err.is_permanent(), "55000 must be permanent: {err}");
+    assert!(
+        err.to_string().contains("55000"),
+        "the SQLSTATE must reach the caller: {err}"
+    );
+}
+
+/// Guard against over-classification: an ordinary SQL error must stay a
+/// retryable `Protocol` error, not get promoted to a permanent slot failure.
+#[test]
+#[ignore = "requires live PostgreSQL"]
+fn ordinary_sql_error_stays_retryable() {
+    init_tracing();
+    let mut regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+
+    // Not `expect_err`: the libpq backend's PgResult is not Debug.
+    let err = match regular.exec("SELECT * FROM it_errcls_table_that_does_not_exist") {
+        Ok(_) => panic!("querying a missing table must fail"),
+        Err(e) => e,
+    };
+
+    assert!(
+        matches!(err, ReplicationError::Protocol(_)),
+        "expected Protocol, got {err:?}"
+    );
+    assert!(
+        !err.is_permanent(),
+        "an ordinary SQL error must stay retryable: {err}"
+    );
+    // 42P01 undefined_table — carried through, but deliberately not promoted.
+    assert!(
+        err.to_string().contains("42P01"),
+        "the SQLSTATE must reach the caller: {err}"
+    );
+}

--- a/integration-tests/streaming_decode.rs
+++ b/integration-tests/streaming_decode.rs
@@ -11,7 +11,7 @@
 //! `-c logical_decoding_work_mem=64kB`:
 //!
 //! ```bash
-//! export DATABASE_URL="postgresql://postgres:postgres@localhost:5433/postgres?replication=database"
+//! export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
 //! cargo test --test streaming_decode -- --ignored --test-threads=1 --nocapture
 //! ```
 //!
@@ -49,7 +49,8 @@ const ROWS: usize = 5000;
 
 fn replication_conn_string() -> String {
     std::env::var("DATABASE_URL").unwrap_or_else(|_| {
-        "postgresql://postgres:postgres@localhost:5433/postgres?replication=database".to_string()
+        "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+            .to_string()
     })
 }
 

--- a/integration-tests/truncate_flags.rs
+++ b/integration-tests/truncate_flags.rs
@@ -1,0 +1,192 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
+//! Integration test for `EventType::Truncate`'s `cascade` / `restart_identity`
+//! flags, and for the first-sighting `EventType::Relation` event.
+//!
+//! pgoutput carries the origin statement's option byte in the Truncate message
+//! (1 = CASCADE, 2 = RESTART IDENTITY). A sink needs both to reproduce the
+//! statement on the target, so this drives all four combinations through a live
+//! server and asserts they arrive intact.
+//!
+//! ## Prerequisites
+//!
+//! - PostgreSQL 15+ with `wal_level = logical`
+//! - `DATABASE_URL` — replication connection
+//! - `DATABASE_URL_REGULAR` — regular connection to the same database
+//!
+//! ## Running Locally
+//!
+//! ```bash
+//! export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+//! export DATABASE_URL_REGULAR="postgresql://postgres:postgres@localhost:5432/test_walstream"
+//! cargo test --test truncate_flags -- --ignored --nocapture --test-threads=1
+//! ```
+
+use pg_walstream::{
+    EventType, LogicalReplicationStream, PgReplicationConnection, ReplicationStreamConfig,
+    RetryConfig, StreamingMode,
+};
+use std::time::Duration;
+use tokio_util::sync::CancellationToken;
+
+fn replication_conn_string() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+            .to_string()
+    })
+}
+
+fn regular_conn_string() -> String {
+    std::env::var("DATABASE_URL_REGULAR").unwrap_or_else(|_| {
+        let repl = replication_conn_string();
+        repl.replace("?replication=database", "")
+            .replace("&replication=database", "")
+    })
+}
+
+fn drop_slot(slot_name: &str) {
+    if let Ok(mut conn) = PgReplicationConnection::connect(&replication_conn_string()) {
+        let _ = conn.exec(&format!(
+            "SELECT pg_drop_replication_slot('{slot_name}') \
+             WHERE EXISTS (SELECT 1 FROM pg_replication_slots WHERE slot_name = '{slot_name}')"
+        ));
+    }
+}
+
+fn cfg(slot: &str) -> ReplicationStreamConfig {
+    ReplicationStreamConfig::new(
+        slot.to_string(),
+        "truncflags_pub".to_string(),
+        2,
+        StreamingMode::Off,
+        Duration::from_secs(10),
+        Duration::from_secs(30),
+        Duration::from_secs(60),
+        RetryConfig::default(),
+    )
+}
+
+/// Drive `TRUNCATE`, `TRUNCATE ... CASCADE`, `TRUNCATE ... RESTART IDENTITY`
+/// and both together through a live server, asserting the decoded flags.
+///
+/// `truncflags_child` has an FK onto `truncflags_parent`, so the bare and
+/// RESTART-IDENTITY-only truncates target the child (truncating the parent
+/// without CASCADE would be rejected by the server).
+#[tokio::test]
+#[ignore = "requires live PostgreSQL with wal_level=logical"]
+async fn truncate_flags_survive_the_wire() {
+    let slot = "it_truncate_flags";
+    drop_slot(slot);
+
+    let mut regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+
+    let _ = regular.exec("DROP TABLE IF EXISTS truncflags_child, truncflags_parent CASCADE");
+    regular
+        .exec("CREATE TABLE truncflags_parent (id SERIAL PRIMARY KEY, payload TEXT)")
+        .expect("create parent");
+    regular
+        .exec(
+            "CREATE TABLE truncflags_child (
+                 id SERIAL PRIMARY KEY,
+                 parent_id INT REFERENCES truncflags_parent(id)
+             )",
+        )
+        .expect("create child");
+
+    let _ = regular.exec("DROP PUBLICATION IF EXISTS truncflags_pub");
+    regular
+        .exec("CREATE PUBLICATION truncflags_pub FOR TABLE truncflags_parent, truncflags_child")
+        .expect("create publication");
+
+    regular
+        .exec(&format!(
+            "SELECT pg_create_logical_replication_slot('{slot}', 'pgoutput')"
+        ))
+        .expect("create slot");
+
+    // Each statement is its own transaction, so the Truncate messages arrive in
+    // this order. `expected` is (cascade, restart_identity).
+    let statements = [
+        ("TRUNCATE truncflags_child", (false, false)),
+        ("TRUNCATE truncflags_parent CASCADE", (true, false)),
+        ("TRUNCATE truncflags_child RESTART IDENTITY", (false, true)),
+        (
+            "TRUNCATE truncflags_parent RESTART IDENTITY CASCADE",
+            (true, true),
+        ),
+    ];
+    for (sql, _) in &statements {
+        regular.exec(sql).unwrap_or_else(|e| panic!("{sql}: {e}"));
+    }
+
+    let mut stream = LogicalReplicationStream::new(&replication_conn_string(), cfg(slot))
+        .await
+        .expect("replication stream");
+    stream.start(None).await.expect("start");
+
+    let cancel = CancellationToken::new();
+    let mut seen: Vec<(Vec<String>, bool, bool)> = Vec::new();
+    let mut relations = 0u32;
+
+    // Bounded so a decode regression fails instead of hanging CI.
+    let collect = async {
+        while seen.len() < statements.len() {
+            match stream.next_event(&cancel).await {
+                Ok(event) => match event.event_type {
+                    EventType::Truncate {
+                        tables,
+                        cascade,
+                        restart_identity,
+                    } => {
+                        seen.push((
+                            tables.iter().map(|t| t.to_string()).collect(),
+                            cascade,
+                            restart_identity,
+                        ));
+                    }
+                    // A first sighting of each relation must surface as an event
+                    // rather than being silently swallowed into the cache.
+                    EventType::Relation { .. } => relations += 1,
+                    _ => {}
+                },
+                Err(e) => panic!("unexpected error: {e}"),
+            }
+        }
+    };
+    tokio::time::timeout(Duration::from_secs(30), collect)
+        .await
+        .expect("all four TRUNCATE events must arrive within 30s");
+
+    for (i, ((sql, (want_cascade, want_restart)), (tables, cascade, restart))) in
+        statements.iter().zip(seen.iter()).enumerate()
+    {
+        assert_eq!(
+            (*cascade, *restart),
+            (*want_cascade, *want_restart),
+            "event {i} for `{sql}`: flags mismatch (tables={tables:?})"
+        );
+        assert!(!tables.is_empty(), "event {i} for `{sql}`: no tables");
+    }
+
+    // CASCADE is expanded before WAL is written, so truncating the parent with
+    // CASCADE reports BOTH published relations, not just the named one.
+    assert_eq!(
+        seen[1].0.len(),
+        2,
+        "CASCADE must report the dependent table too, got {:?}",
+        seen[1].0
+    );
+
+    assert!(
+        relations >= 1,
+        "the first Relation message for a table must surface as an event"
+    );
+
+    drop(stream);
+    tokio::time::sleep(Duration::from_millis(200)).await;
+    drop_slot(slot);
+
+    let _ = regular.exec("DROP PUBLICATION IF EXISTS truncflags_pub");
+    let _ = regular.exec("DROP TABLE IF EXISTS truncflags_child, truncflags_parent CASCADE");
+}

--- a/integration-tests/upload_manifest.rs
+++ b/integration-tests/upload_manifest.rs
@@ -1,0 +1,231 @@
+#![cfg(any(feature = "libpq", feature = "rustls-tls"))]
+
+//! Integration test for `UPLOAD_MANIFEST` + `BASE_BACKUP (INCREMENTAL)`.
+//!
+//! An incremental backup is a two-step conversation on one connection:
+//! `UPLOAD_MANIFEST` (Query → CopyInResponse → CopyData* → CopyDone →
+//! CommandComplete) carrying the `backup_manifest` of a prior full backup, then
+//! `BASE_BACKUP (... INCREMENTAL)`. Both steps are exercised here; the manifest
+//! is only validated by the server once the CopyIn completes, so the negative
+//! case also proves the whole round-trip is wired up.
+//!
+//! ## Prerequisites
+//!
+//! - PostgreSQL 17+ (the command does not exist earlier) — skips gracefully below
+//! - `summarize_wal = on` for the positive case — skips gracefully when off
+//! - `DATABASE_URL` — replication connection
+//! - `DATABASE_URL_REGULAR` — regular connection to the same database
+//! - `BACKUP_MANIFEST_PATH` — path to a real `backup_manifest` from a prior full
+//!   backup of *this* cluster. Without it the positive case is skipped; the
+//!   negative cases still run.
+//!
+//! ## Running Locally
+//!
+//! ```bash
+//! export DATABASE_URL="postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+//! export DATABASE_URL_REGULAR="postgresql://postgres:postgres@localhost:5432/test_walstream"
+//! pg_basebackup -h localhost -U postgres -D /tmp/bb -Fp -X stream --no-sync
+//! export BACKUP_MANIFEST_PATH=/tmp/bb/backup_manifest
+//! cargo test --test upload_manifest -- --ignored --nocapture --test-threads=1
+//! ```
+
+use pg_walstream::{BaseBackupOptions, PgReplicationConnection};
+use tracing::warn;
+
+fn replication_conn_string() -> String {
+    std::env::var("DATABASE_URL").unwrap_or_else(|_| {
+        "postgresql://postgres:postgres@localhost:5432/test_walstream?replication=database"
+            .to_string()
+    })
+}
+
+fn regular_conn_string() -> String {
+    std::env::var("DATABASE_URL_REGULAR").unwrap_or_else(|_| {
+        let repl = replication_conn_string();
+        repl.replace("?replication=database", "")
+            .replace("&replication=database", "")
+    })
+}
+
+fn init_tracing() {
+    let _ = tracing_subscriber::fmt()
+        .with_max_level(tracing::Level::INFO)
+        .try_init();
+}
+
+fn show(conn: &mut PgReplicationConnection, name: &str) -> String {
+    conn.exec(&format!("SHOW {name}"))
+        .unwrap_or_else(|e| panic!("SHOW {name}: {e}"))
+        .get_value(0, 0)
+        .unwrap_or_else(|| panic!("SHOW {name} returned no value"))
+}
+
+/// `true` when the server is PostgreSQL 17+, i.e. `UPLOAD_MANIFEST` exists.
+fn server_supports_upload_manifest() -> bool {
+    let mut regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    let version: i64 = show(&mut regular, "server_version_num")
+        .parse()
+        .expect("server_version_num is numeric");
+    if version < 170000 {
+        warn!("skipping: UPLOAD_MANIFEST requires PostgreSQL 17+, server is {version}");
+        return false;
+    }
+    true
+}
+
+/// The full round-trip: a real manifest is accepted, and the incremental
+/// `BASE_BACKUP` that depends on it is then accepted too.
+///
+/// Needs `BACKUP_MANIFEST_PATH` (CI runs `pg_basebackup` first) and
+/// `summarize_wal = on`; skips gracefully otherwise.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL 17+ and a backup manifest"]
+async fn real_manifest_enables_incremental_base_backup() {
+    init_tracing();
+    if !server_supports_upload_manifest() {
+        return;
+    }
+
+    let Ok(path) = std::env::var("BACKUP_MANIFEST_PATH") else {
+        warn!("skipping: BACKUP_MANIFEST_PATH is not set");
+        return;
+    };
+    let manifest = match std::fs::read(&path) {
+        Ok(m) => m,
+        Err(e) => {
+            warn!("skipping: cannot read BACKUP_MANIFEST_PATH={path}: {e}");
+            return;
+        }
+    };
+    assert!(!manifest.is_empty(), "manifest at {path} is empty");
+
+    let mut regular =
+        PgReplicationConnection::connect(&regular_conn_string()).expect("regular connection");
+    if show(&mut regular, "summarize_wal") != "on" {
+        warn!("skipping: incremental backup requires summarize_wal = on");
+        return;
+    }
+
+    let mut repl = PgReplicationConnection::connect(&replication_conn_string())
+        .expect("replication connection");
+
+    repl.upload_manifest(&manifest)
+        .expect("a real backup_manifest must be accepted");
+
+    // The server keeps the manifest for the life of the connection, so the
+    // incremental backup must run on this same connection. Entering the COPY
+    // stream is the assertion — the payload is not drained; the connection is
+    // dropped immediately after, which aborts the backup server-side.
+    let opts = BaseBackupOptions {
+        incremental: true,
+        label: Some("it_upload_manifest".to_string()),
+        ..Default::default()
+    };
+    repl.base_backup(&opts)
+        .expect("INCREMENTAL base backup must be accepted after UPLOAD_MANIFEST");
+}
+
+/// Without a prior `UPLOAD_MANIFEST` the server rejects an incremental backup.
+///
+/// This is the failure the option used to produce unconditionally, when the
+/// crate exposed `incremental` with no way to upload a manifest at all.
+#[tokio::test]
+#[ignore = "requires live PostgreSQL 17+"]
+async fn incremental_without_manifest_is_rejected() {
+    init_tracing();
+    if !server_supports_upload_manifest() {
+        return;
+    }
+
+    let mut repl = PgReplicationConnection::connect(&replication_conn_string())
+        .expect("replication connection");
+
+    let opts = BaseBackupOptions {
+        incremental: true,
+        ..Default::default()
+    };
+    let err = match repl.base_backup(&opts) {
+        Ok(_) => panic!("INCREMENTAL without UPLOAD_MANIFEST must fail"),
+        Err(e) => e,
+    };
+    assert!(
+        err.to_string().contains("UPLOAD_MANIFEST"),
+        "expected the server's must-UPLOAD_MANIFEST error, got: {err}"
+    );
+}
+
+/// A malformed manifest must surface the server's diagnostics rather than
+/// hanging or reporting success.
+///
+/// The server only validates after the CopyIn completes, so reaching this error
+/// proves the full `Query → CopyInResponse → CopyData → CopyDone → ErrorResponse`
+/// exchange works on this backend.
+#[test]
+#[ignore = "requires live PostgreSQL 17+"]
+fn malformed_manifest_is_rejected_after_the_copy_completes() {
+    init_tracing();
+    if !server_supports_upload_manifest() {
+        return;
+    }
+
+    let mut repl = PgReplicationConnection::connect(&replication_conn_string())
+        .expect("replication connection");
+
+    let err = repl
+        .upload_manifest(b"this is not a backup manifest")
+        .expect_err("a malformed manifest must be rejected");
+    assert!(
+        err.to_string().to_lowercase().contains("manifest"),
+        "expected a manifest-specific error, got: {err}"
+    );
+
+    // A rejected upload must leave the connection usable, not wedged mid-CopyIn.
+    let after = repl
+        .exec("IDENTIFY_SYSTEM")
+        .expect("connection must still be usable after a rejected manifest");
+    assert!(after.ntuples() > 0, "IDENTIFY_SYSTEM returned no rows");
+}
+
+/// A manifest that parses as JSON but carries a wrong `Manifest-Checksum`
+/// must be rejected — the checksum is what makes the upload trustworthy.
+///
+/// Manifest version 2 is required: version 1 predates incremental backup and is
+/// refused before the checksum is ever examined. Version 2 also carries a
+/// `System-Identifier`, which must match this cluster, so it is read back from
+/// `IDENTIFY_SYSTEM` rather than hard-coded.
+#[test]
+#[ignore = "requires live PostgreSQL 17+"]
+fn manifest_with_bad_checksum_is_rejected() {
+    init_tracing();
+    if !server_supports_upload_manifest() {
+        return;
+    }
+
+    let mut repl = PgReplicationConnection::connect(&replication_conn_string())
+        .expect("replication connection");
+
+    let system_id = repl
+        .exec("IDENTIFY_SYSTEM")
+        .expect("IDENTIFY_SYSTEM")
+        .get_value(0, 0)
+        .expect("systemid column");
+
+    let manifest = format!(
+        r#"{{ "PostgreSQL-Backup-Manifest-Version": 2,
+"System-Identifier": {system_id},
+"Files": [],
+"WAL-Ranges": [],
+"Manifest-Checksum": "{}"}}
+"#,
+        "0".repeat(64)
+    );
+
+    let err = repl
+        .upload_manifest(manifest.as_bytes())
+        .expect_err("a wrong Manifest-Checksum must be rejected");
+    assert!(
+        err.to_string().to_lowercase().contains("checksum"),
+        "expected a checksum error, got: {err}"
+    );
+}

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -15,6 +15,6 @@ categories = ["database"]
 proc-macro = true
 
 [dependencies]
-syn = "3.0.3"
+syn = "3.0.5"
 quote = "1.0.47"
 proc-macro2 = "1.0.107"

--- a/src/column_value.rs
+++ b/src/column_value.rs
@@ -343,6 +343,18 @@ impl<'de> Deserialize<'de> for ColumnValue {
 /// assert_eq!(row.len(), 2);
 /// assert_eq!(row.get("id").and_then(|v| v.as_str()), Some("1"));
 /// ```
+///
+/// pgoutput encodes an out-of-line (TOASTed) column that an UPDATE did not
+/// touch as `'u'`, which this crate drops from the row entirely. A SQL NULL is
+/// always materialised as [`ColumnValue::Null`], so "absent from the row" is an
+/// unambiguous encoding of "unchanged — reuse the value already in the target".
+///
+/// A sink must therefore build partial `UPDATE` statements from what the row
+/// actually contains (iterate, or check [`get`](Self::get) for `None`).
+/// Substituting NULL for a missing column overwrites good data with nulls.
+/// Setting the table's `REPLICA IDENTITY FULL` does not change this; only
+/// `ALTER TABLE ... SET (toast_tuple_target = ...)` or keeping the column
+/// inline avoids it.
 #[derive(Debug, Clone, Eq)]
 pub struct RowData {
     columns: SmallVec<[(Arc<str>, ColumnValue); 8]>,

--- a/src/connection/libpq.rs
+++ b/src/connection/libpq.rs
@@ -52,17 +52,46 @@ enum ReadResult {
     WouldBlock,
     /// COPY stream has ended gracefully
     CopyDone,
+    /// COPY stream was ended by a server error: `(sqlstate, message)`
+    CopyFailed(String, String),
 }
 
 /// Result of draining all available messages from libpq
 #[derive(Debug, PartialEq)]
 enum DrainResult {
-    /// One or more messages were queued
-    Drained,
-    /// No complete message available
+    /// Messages were queued, and/or the end of the COPY stream was latched.
+    /// Either way the caller loops: it drains the queue first, then acts on the
+    /// latch.
+    Progressed,
+    /// No complete message available and the stream is still open.
     WouldBlock,
-    /// COPY stream has ended
-    CopyDone,
+}
+
+/// How the COPY stream ended, latched on the connection.
+///
+/// `PQgetCopyData` reports the end of the stream only once, and it can do so in
+/// the same drain pass that queued messages. Reporting the end immediately would
+/// discard those messages, so the terminal state is parked here and surfaces
+/// only after the queue is empty. It is sticky rather than consumed: once the
+/// stream is over, every subsequent read reports the same reason.
+#[derive(Debug, Clone, PartialEq)]
+enum CopyEnd {
+    /// Graceful CopyDone.
+    Done,
+    /// The server terminated the stream: `(sqlstate, message)`.
+    Failed(String, String),
+}
+
+impl CopyEnd {
+    fn to_error(&self) -> ReplicationError {
+        match self {
+            CopyEnd::Done => ReplicationError::Cancelled("COPY stream ended".to_string()),
+            CopyEnd::Failed(sqlstate, message) => ReplicationError::from_sqlstate(
+                sqlstate,
+                format!("replication stream terminated by server: {message}"),
+            ),
+        }
+    }
 }
 
 /// Maximum messages to drain from libpq in a single batch.
@@ -75,6 +104,11 @@ const MAX_DRAIN_BATCH: usize = 4096;
 /// 64 KiB to amortize `PQgetCopyData` → `BytesMut::put_slice` copies under
 /// bulk WAL traffic.
 const READ_BUF_INITIAL_CAPACITY: usize = 256 * 1024;
+
+/// Largest payload put in a single `PQputCopyData` call.
+///
+/// A backup manifest is a few hundred KiB; chunking bounds libpq's output buffer and keeps each message far below the server's 1 GiB message limit.
+const COPY_IN_CHUNK: usize = 64 * 1024;
 
 /// Safe wrapper around PostgreSQL connection for replication
 ///
@@ -121,6 +155,8 @@ pub struct PgReplicationConnection {
     pending_messages: VecDeque<Bytes>,
     /// Reusable buffer for copying data from libpq (avoids per-message heap alloc).
     read_buf: BytesMut,
+    /// How the COPY stream ended, once it has. Surfaces only after `pending_messages` is drained, so a stream that ends in the same pass that queued messages still delivers them.
+    copy_end: Option<CopyEnd>,
 }
 
 impl PgReplicationConnection {
@@ -245,6 +281,7 @@ impl PgReplicationConnection {
             async_fd: None,
             pending_messages: VecDeque::with_capacity(MAX_DRAIN_BATCH),
             read_buf: BytesMut::with_capacity(READ_BUF_INITIAL_CAPACITY),
+            copy_end: None,
         })
     }
 
@@ -279,9 +316,10 @@ impl PgReplicationConnection {
             let error_msg = pg_result
                 .error_message()
                 .unwrap_or_else(|| "Unknown error".to_string());
-            return Err(ReplicationError::protocol(format!(
-                "Query execution failed: {error_msg}"
-            )));
+            return Err(ReplicationError::from_sqlstate(
+                &pg_result.error_sqlstate(),
+                format!("Query execution failed: {error_msg}"),
+            ));
         }
 
         Ok(pg_result)
@@ -319,6 +357,9 @@ impl PgReplicationConnection {
 
         debug!("Starting replication: {}", sql);
         let _result = self.exec(&sql)?;
+
+        // A fresh COPY stream: drop any terminal state left by a previous one.
+        self.copy_end = None;
 
         // Initialize the async socket first; mark the connection as being in replication mode only AFTER it succeeds, preserving the invariant `is_replication_conn == true ⇒ async_fd is Some`. Otherwise a failed socket setup would leave the flag true with no async_fd, and a later `end_copy`/Drop would reach the writable-wait path with `async_fd == None`.
         self.initialize_async_socket()?;
@@ -411,14 +452,20 @@ impl PgReplicationConnection {
                 return Ok(msg);
             }
 
+            // Queue empty: a latched end of stream now takes effect.
+            if let Some(end) = &self.copy_end {
+                return Err(end.to_error());
+            }
+
             // ── Try to drain any messages already buffered inside libpq ──
-            match drain_buffered_messages(self.conn, &mut self.pending_messages, &mut self.read_buf)
-            {
-                DrainResult::Drained => continue, // messages queued, loop to pop
-                DrainResult::CopyDone => {
-                    debug!("COPY stream ended gracefully");
-                    return Err(ReplicationError::Cancelled("COPY stream ended".to_string()));
-                }
+            match drain_buffered_messages(
+                self.conn,
+                &mut self.pending_messages,
+                &mut self.read_buf,
+                &mut self.copy_end,
+            ) {
+                // Messages queued and/or the stream ended: loop to pop, then latch.
+                DrainResult::Progressed => continue,
                 DrainResult::WouldBlock => {} // need to wait for socket
             }
 
@@ -448,15 +495,11 @@ impl PgReplicationConnection {
                     }
 
                     // Drain all available messages
-                    match drain_buffered_messages(self.conn, &mut self.pending_messages, &mut self.read_buf) {
-                        DrainResult::Drained => {
-                            // Messages queued; guard drops and clears ready flag
-                        }
-                        DrainResult::CopyDone => {
-                            debug!("COPY stream ended after consuming input");
-                            return Err(ReplicationError::Cancelled(
-                                "COPY stream ended".to_string(),
-                            ));
+                    match drain_buffered_messages(self.conn, &mut self.pending_messages, &mut self.read_buf, &mut self.copy_end) {
+                        DrainResult::Progressed => {
+                            // Messages queued and/or the stream ended; the next
+                            // loop iteration pops the queue, then the latch.
+                            // Guard drops and clears ready flag.
                         }
                         DrainResult::WouldBlock => {
                             // No complete message yet, clear ready flag to re-arm epoll
@@ -477,16 +520,21 @@ impl PgReplicationConnection {
             return Ok(msg);
         }
         // Try one last drain
-        match drain_buffered_messages(self.conn, &mut self.pending_messages, &mut self.read_buf) {
-            DrainResult::Drained => {
+        match drain_buffered_messages(
+            self.conn,
+            &mut self.pending_messages,
+            &mut self.read_buf,
+            &mut self.copy_end,
+        ) {
+            DrainResult::Progressed => {
                 if let Some(msg) = self.pending_messages.pop_front() {
                     info!("Found buffered data after cancellation, returning it");
                     return Ok(msg);
                 }
-            }
-            DrainResult::CopyDone => {
-                info!("COPY stream ended during cancellation check");
-                return Err(ReplicationError::Cancelled("COPY stream ended".to_string()));
+                if let Some(end) = &self.copy_end {
+                    info!("COPY stream ended during cancellation check");
+                    return Err(end.to_error());
+                }
             }
             DrainResult::WouldBlock => {
                 info!("Cancellation token triggered with no buffered data");
@@ -818,6 +866,111 @@ impl PgReplicationConnection {
         Ok(())
     }
 
+    /// Upload a backup manifest in preparation for an incremental base backup.
+    ///
+    /// Sends `UPLOAD_MANIFEST` and streams `manifest` (the `backup_manifest` file from the prior full backup) into the resulting CopyIn. The server keeps it for the duration of the connection, so the following  [`base_backup`](Self::base_backup) with [`BaseBackupOptions::incremental`] must run on this same connection.
+    ///
+    /// Requires PostgreSQL 17+. The server also needs `summarize_wal = on`, or the subsequent incremental backup fails with a WAL-summary error.
+    pub fn upload_manifest(&mut self, manifest: &[u8]) -> Result<()> {
+        crate::sql_builder::check_upload_manifest_version(self.server_version())?;
+
+        let c_query = CString::new("UPLOAD_MANIFEST")
+            .map_err(|e| ReplicationError::protocol(format!("Invalid query string: {e}")))?;
+
+        // `exec` rejects PGRES_COPY_IN, and PQputCopyData would have to be
+        // flush-looped in non-blocking mode. This is a one-shot setup step on a
+        // connection that has not started streaming yet, so drop to blocking
+        // for the transfer and restore the caller's mode afterwards.
+        let was_nonblocking = unsafe { PQisnonblocking(self.conn) } == 1;
+        if was_nonblocking && unsafe { PQsetnonblocking(self.conn, 0) } != 0 {
+            return Err(ReplicationError::protocol(
+                "Failed to set blocking mode for UPLOAD_MANIFEST".to_string(),
+            ));
+        }
+        let restore = |conn| {
+            if was_nonblocking {
+                unsafe { PQsetnonblocking(conn, 1) };
+            }
+        };
+
+        debug!("Uploading backup manifest ({} bytes)", manifest.len());
+        let res = unsafe { PQexec(self.conn, c_query.as_ptr()) };
+        if res.is_null() {
+            restore(self.conn);
+            return Err(ReplicationError::protocol(
+                "UPLOAD_MANIFEST failed - null result".to_string(),
+            ));
+        }
+        let pg_result = PgResult::new(res);
+        if !matches!(pg_result.status(), ExecStatusType::PGRES_COPY_IN) {
+            restore(self.conn);
+            let error_msg = pg_result
+                .error_message()
+                .unwrap_or_else(|| "Unknown error".to_string());
+            return Err(ReplicationError::from_sqlstate(
+                &pg_result.error_sqlstate(),
+                format!("UPLOAD_MANIFEST did not enter CopyIn mode: {error_msg}"),
+            ));
+        }
+        drop(pg_result);
+
+        // The server validates the manifest only once the CopyIn completes, so
+        // the whole payload goes out before any verdict is available.
+        for chunk in manifest.chunks(COPY_IN_CHUNK) {
+            let sent = unsafe {
+                PQputCopyData(
+                    self.conn,
+                    chunk.as_ptr().cast::<std::os::raw::c_char>(),
+                    chunk.len() as i32,
+                )
+            };
+            if sent != 1 {
+                let error_msg = self.last_error_message();
+                restore(self.conn);
+                return Err(ReplicationError::protocol(format!(
+                    "PQputCopyData failed while uploading manifest: {error_msg}"
+                )));
+            }
+        }
+        if unsafe { PQputCopyEnd(self.conn, ptr::null()) } != 1 {
+            let error_msg = self.last_error_message();
+            restore(self.conn);
+            return Err(ReplicationError::protocol(format!(
+                "PQputCopyEnd failed while uploading manifest: {error_msg}"
+            )));
+        }
+
+        // Drain every trailing result; libpq needs them reclaimed and the first
+        // failure carries the manifest diagnostics.
+        let mut failure = None;
+        loop {
+            let raw = unsafe { PQgetResult(self.conn) };
+            if raw.is_null() {
+                break;
+            }
+            let res = PgResult::new(raw);
+            if !matches!(res.status(), ExecStatusType::PGRES_COMMAND_OK) && failure.is_none() {
+                failure = Some(ReplicationError::from_sqlstate(
+                    &res.error_sqlstate(),
+                    format!(
+                        "UPLOAD_MANIFEST failed: {}",
+                        res.error_message()
+                            .unwrap_or_else(|| "Unknown error".to_string())
+                    ),
+                ));
+            }
+        }
+        restore(self.conn);
+
+        match failure {
+            Some(e) => Err(e),
+            None => {
+                debug!("Backup manifest uploaded");
+                Ok(())
+            }
+        }
+    }
+
     /// Start a base backup with options
     pub fn base_backup(&mut self, options: &BaseBackupOptions) -> Result<PgResult> {
         let base_backup_sql =
@@ -892,6 +1045,7 @@ impl PgReplicationConnection {
             async_fd: None,
             pending_messages: VecDeque::new(),
             read_buf: BytesMut::new(),
+            copy_end: None,
         }
     }
 
@@ -994,6 +1148,20 @@ impl PgResult {
             unsafe { Some(CStr::from_ptr(error_ptr).to_string_lossy().into_owned()) }
         }
     }
+
+    /// The result's SQLSTATE, or `""` when the server supplied no diagnostics.
+    ///
+    /// Unlike [`error_message`](Self::error_message), this is stable across
+    /// PostgreSQL major versions, so it is what `ReplicationError::from_sqlstate`
+    /// classifies on. Crate-internal: `exec` maps every non-OK result to `Err`, so callers never hold a failing result.
+    pub(crate) fn error_sqlstate(&self) -> String {
+        let ptr = unsafe { PQresultErrorField(self.result, PG_DIAG_SQLSTATE as i32) };
+        if ptr.is_null() {
+            String::new()
+        } else {
+            unsafe { CStr::from_ptr(ptr).to_string_lossy().into_owned() }
+        }
+    }
 }
 
 impl Drop for PgResult {
@@ -1013,6 +1181,46 @@ unsafe impl Send for PgResult {}
 // These are free functions (not methods) to avoid borrow-checker conflicts:
 // `get_copy_data_async` needs `&self.async_fd` (immutable borrow of struct)
 // while simultaneously calling these to mutate `pending_messages` / `read_buf`.
+
+/// Classify why the COPY stream ended.
+///
+/// `PQgetCopyData` returns -1 both for a clean `CopyDone` and for a server error
+/// that terminated the stream — only the trailing `PGresult` distinguishes them.
+/// Without this, `pg_terminate_backend`, a `wal_sender_timeout` expiry, or a slot
+/// invalidation are indistinguishable from a graceful shutdown, and the caller
+/// reports a clean exit while the server's diagnostics are discarded.
+///
+/// `PQgetResult` blocks on a non-blocking connection when the result is not yet
+/// complete, so results are only collected while `PQisBusy` says libpq has
+/// already parsed one. An `ErrorResponse` that ended the COPY is always
+/// available: libpq stores it before leaving copy mode.
+fn copy_end_status(conn: *mut PGconn) -> ReadResult {
+    let mut end = ReadResult::CopyDone;
+
+    while unsafe { PQisBusy(conn) } == 0 {
+        let raw = unsafe { PQgetResult(conn) };
+        if raw.is_null() {
+            break;
+        }
+        // Wrapped so PQclear runs on drop; libpq needs every result reclaimed.
+        let res = PgResult::new(raw);
+        if matches!(res.status(), ExecStatusType::PGRES_FATAL_ERROR)
+            && matches!(end, ReadResult::CopyDone)
+        {
+            let message = res
+                .error_message()
+                .unwrap_or_else(|| "Unknown error".to_string());
+            let sqlstate = res.error_sqlstate();
+            warn!("COPY stream terminated by server [{sqlstate}]: {message}");
+            end = ReadResult::CopyFailed(sqlstate, message);
+        }
+    }
+
+    if matches!(end, ReadResult::CopyDone) {
+        debug!("COPY stream finished gracefully (PQgetCopyData returned -1)");
+    }
+    end
+}
 
 /// Read a single message from libpq's internal buffer using a reusable `BytesMut`.
 ///
@@ -1047,10 +1255,7 @@ fn try_read_buffered_data_raw(conn: *mut PGconn, read_buf: &mut BytesMut) -> Res
             Ok(ReadResult::Data(data))
         }
         0 => Ok(ReadResult::WouldBlock),
-        -1 => {
-            debug!("COPY stream finished (PQgetCopyData returned -1)");
-            Ok(ReadResult::CopyDone)
-        }
+        -1 => Ok(copy_end_status(conn)),
         -2 => {
             let error_msg = unsafe {
                 let error_ptr = PQerrorMessage(conn);
@@ -1080,6 +1285,7 @@ fn drain_buffered_messages(
     conn: *mut PGconn,
     pending_messages: &mut VecDeque<Bytes>,
     read_buf: &mut BytesMut,
+    copy_end: &mut Option<CopyEnd>,
 ) -> DrainResult {
     let mut drained = false;
 
@@ -1090,13 +1296,21 @@ fn drain_buffered_messages(
                 drained = true;
             }
             Ok(ReadResult::WouldBlock) => break,
-            Ok(ReadResult::CopyDone) => return DrainResult::CopyDone,
+            // Latch and stop reading; anything already queued is delivered first.
+            Ok(ReadResult::CopyDone) => {
+                *copy_end = Some(CopyEnd::Done);
+                break;
+            }
+            Ok(ReadResult::CopyFailed(sqlstate, message)) => {
+                *copy_end = Some(CopyEnd::Failed(sqlstate, message));
+                break;
+            }
             Err(_) => break, // treat errors as would-block for drain purposes
         }
     }
 
-    if drained {
-        DrainResult::Drained
+    if drained || copy_end.is_some() {
+        DrainResult::Progressed
     } else {
         DrainResult::WouldBlock
     }
@@ -1458,37 +1672,62 @@ mod tests {
     // ========================================
 
     #[test]
-    fn test_drain_result_drained_variant() {
-        let result = DrainResult::Drained;
-        assert_eq!(result, DrainResult::Drained);
-        assert_ne!(result, DrainResult::WouldBlock);
-        assert_ne!(result, DrainResult::CopyDone);
-    }
-
-    #[test]
-    fn test_drain_result_would_block_variant() {
-        let result = DrainResult::WouldBlock;
-        assert_eq!(result, DrainResult::WouldBlock);
-        assert_ne!(result, DrainResult::Drained);
-    }
-
-    #[test]
-    fn test_drain_result_copy_done_variant() {
-        let result = DrainResult::CopyDone;
-        assert_eq!(result, DrainResult::CopyDone);
-        assert_ne!(result, DrainResult::Drained);
+    fn test_drain_result_variants() {
+        assert_eq!(DrainResult::Progressed, DrainResult::Progressed);
+        assert_ne!(DrainResult::Progressed, DrainResult::WouldBlock);
     }
 
     #[test]
     fn test_drain_result_debug_format() {
-        let drained = format!("{:?}", DrainResult::Drained);
-        assert!(drained.contains("Drained"));
+        assert!(format!("{:?}", DrainResult::Progressed).contains("Progressed"));
+        assert!(format!("{:?}", DrainResult::WouldBlock).contains("WouldBlock"));
+    }
 
-        let would_block = format!("{:?}", DrainResult::WouldBlock);
-        assert!(would_block.contains("WouldBlock"));
+    // ========================================
+    // CopyEnd latch
+    // ========================================
 
-        let copy_done = format!("{:?}", DrainResult::CopyDone);
-        assert!(copy_done.contains("CopyDone"));
+    /// A graceful end is reported as `Cancelled`; a server-terminated one keeps
+    /// its SQLSTATE classification, so an invalidated slot stays permanent.
+    #[test]
+    fn test_copy_end_to_error() {
+        assert!(matches!(
+            CopyEnd::Done.to_error(),
+            ReplicationError::Cancelled(_)
+        ));
+
+        let invalidated =
+            CopyEnd::Failed("55000".to_string(), "can no longer access slot".to_string())
+                .to_error();
+        assert!(matches!(invalidated, ReplicationError::ReplicationSlot(_)));
+        assert!(invalidated.is_permanent());
+        assert!(invalidated.to_string().contains("55000"), "{invalidated}");
+
+        let other = CopyEnd::Failed("57P01".to_string(), "terminating".to_string()).to_error();
+        assert!(matches!(other, ReplicationError::Protocol(_)));
+        assert!(!other.is_permanent());
+    }
+
+    /// Regression: a drain pass that queues messages and *then* sees the end of
+    /// the stream must deliver the messages first. Reporting the end immediately
+    /// used to discard everything still queued.
+    #[test]
+    fn test_latched_copy_end_surfaces_only_after_the_queue_drains() {
+        let mut conn = PgReplicationConnection::null_for_testing();
+        conn.push_pending_message_for_testing(Bytes::from_static(b"first"));
+        conn.push_pending_message_for_testing(Bytes::from_static(b"second"));
+        conn.copy_end = Some(CopyEnd::Done);
+
+        // handle_cancellation drains the queue before honouring the latch.
+        assert_eq!(conn.handle_cancellation().unwrap(), &b"first"[..]);
+        assert_eq!(conn.handle_cancellation().unwrap(), &b"second"[..]);
+    }
+
+    /// The latch is sticky: once the stream is over, every read reports why.
+    #[test]
+    fn test_copy_end_latch_is_sticky() {
+        let end = CopyEnd::Failed("55000".to_string(), "gone".to_string());
+        assert_eq!(end.to_error().to_string(), end.to_error().to_string());
     }
 
     // ========================================

--- a/src/connection/native/connection.rs
+++ b/src/connection/native/connection.rs
@@ -37,6 +37,13 @@ enum Command {
         sql: String,
         reply: std_mpsc::Sender<Result<NativePgResult>>,
     },
+    /// Run a simple query that answers with `CopyInResponse`, streaming
+    /// `payload` into it. Only `UPLOAD_MANIFEST` uses this.
+    QueryCopyIn {
+        sql: String,
+        payload: Bytes,
+        reply: std_mpsc::Sender<Result<NativePgResult>>,
+    },
     /// Enter the streaming push loop: the worker continuously reads CopyData
     /// batches and pushes them down `batch_tx` until the token is cancelled, the
     /// receiver is dropped, or a read error occurs. Replaces the old per-event
@@ -84,6 +91,10 @@ struct Worker {
 impl Worker {
     async fn query(&mut self, sql: &str) -> Result<NativePgResult> {
         query::simple_query(&mut self.transport, &mut self.read_buf, sql).await
+    }
+
+    async fn query_copy_in(&mut self, sql: &str, payload: &[u8]) -> Result<NativePgResult> {
+        query::simple_query_copy_in(&mut self.transport, &mut self.read_buf, sql, payload).await
     }
 
     /// Streaming push loop. Continuously reads CopyData batches and pushes them to `batch_tx`, while still servicing interleaved commands (feedback `PutCopyData`, `Close`) on `cmd_rx`. Returns `true` if a `Close` was  handled (the worker should stop), `false` if streaming ended for any other reason (cancel, read error, or the consumer dropped the receiver).
@@ -154,6 +165,14 @@ impl Worker {
             }
             Some(Command::Query { sql, reply }) => {
                 let _ = reply.send(self.query(&sql).await);
+                StreamCmd::Continue
+            }
+            Some(Command::QueryCopyIn {
+                sql,
+                payload,
+                reply,
+            }) => {
+                let _ = reply.send(self.query_copy_in(&sql, &payload).await);
                 StreamCmd::Continue
             }
             Some(Command::Close {
@@ -292,6 +311,13 @@ fn run_worker(
             match cmd {
                 Command::Query { sql, reply } => {
                     let _ = reply.send(worker.query(&sql).await);
+                }
+                Command::QueryCopyIn {
+                    sql,
+                    payload,
+                    reply,
+                } => {
+                    let _ = reply.send(worker.query_copy_in(&sql, &payload).await);
                 }
                 Command::StreamCopy { token, batch_tx } => {
                     // Runs its own loop, servicing interleaved commands, until
@@ -501,6 +527,26 @@ impl NativeConnection {
         }
     }
 
+    /// Run a CopyIn query: inline on the worker, or over the command channel.
+    fn run_query_copy_in(&mut self, sql: &str, payload: &[u8]) -> Result<NativePgResult> {
+        match &mut self.driver {
+            Driver::Inline { worker, handle, .. } => {
+                run_sync(handle, worker.query_copy_in(sql, payload))
+            }
+            Driver::Threaded { cmd_tx, .. } => {
+                let (reply_tx, reply_rx) = std_mpsc::channel();
+                cmd_tx
+                    .send(Command::QueryCopyIn {
+                        sql: sql.to_string(),
+                        payload: Bytes::copy_from_slice(payload),
+                        reply: reply_tx,
+                    })
+                    .map_err(|_| Self::worker_gone())?;
+                reply_rx.recv().map_err(|_| Self::worker_gone())?
+            }
+        }
+    }
+
     #[cold]
     fn worker_gone() -> ReplicationError {
         ReplicationError::backend("native worker thread is gone")
@@ -522,9 +568,10 @@ impl NativeConnection {
             let error_msg = result
                 .error_message()
                 .unwrap_or_else(|| "Unknown error".to_string());
-            return Err(ReplicationError::protocol(format!(
-                "Query execution failed: {error_msg}"
-            )));
+            return Err(ReplicationError::from_sqlstate(
+                &result.error_sqlstate(),
+                format!("Query execution failed: {error_msg}"),
+            ));
         }
 
         Ok(result)
@@ -568,9 +615,10 @@ impl NativeConnection {
             let error_msg = result
                 .error_message()
                 .unwrap_or_else(|| "Unknown error".to_string());
-            return Err(ReplicationError::protocol(format!(
-                "START_REPLICATION did not enter COPY mode: {error_msg}"
-            )));
+            return Err(ReplicationError::from_sqlstate(
+                &result.error_sqlstate(),
+                format!("START_REPLICATION did not enter COPY mode: {error_msg}"),
+            ));
         }
 
         self.in_copy_mode = true;
@@ -908,14 +956,38 @@ impl NativeConnection {
                 let error_msg = result
                     .error_message()
                     .unwrap_or_else(|| "Unknown error".to_string());
-                return Err(ReplicationError::protocol(format!(
-                    "START_REPLICATION did not enter COPY mode: {error_msg}"
-                )));
+                return Err(ReplicationError::from_sqlstate(
+                    &result.error_sqlstate(),
+                    format!("START_REPLICATION did not enter COPY mode: {error_msg}"),
+                ));
             }
         }
 
         self.in_copy_mode = true;
         debug!("Physical replication started successfully");
+        Ok(())
+    }
+
+    /// Upload a backup manifest in preparation for an incremental base backup.
+    ///
+    /// Sends `UPLOAD_MANIFEST` and streams `manifest` (the `backup_manifest` file from the prior full backup) into the resulting CopyIn. The server keeps it for the duration of the connection, so the following  [`base_backup`](Self::base_backup) with [`BaseBackupOptions::incremental`] must run on this same connection.
+    ///
+    /// Requires PostgreSQL 17+. The server also needs `summarize_wal = on`, or the subsequent incremental backup fails with a WAL-summary error.
+    pub fn upload_manifest(&mut self, manifest: &[u8]) -> Result<()> {
+        crate::sql_builder::check_upload_manifest_version(self.server_version())?;
+
+        debug!("Uploading backup manifest ({} bytes)", manifest.len());
+        let result = self.run_query_copy_in("UPLOAD_MANIFEST", manifest)?;
+        if !result.is_ok() {
+            let error_msg = result
+                .error_message()
+                .unwrap_or_else(|| "Unknown error".to_string());
+            return Err(ReplicationError::from_sqlstate(
+                &result.error_sqlstate(),
+                format!("UPLOAD_MANIFEST failed: {error_msg}"),
+            ));
+        }
+        debug!("Backup manifest uploaded");
         Ok(())
     }
 
@@ -1363,22 +1435,21 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn test_base_backup_preflight_rejects_incremental_below_pg17() {
-        let mut conn = NativeConnection::null_for_testing();
-        let opts = BaseBackupOptions {
-            incremental: true,
-            ..Default::default()
-        };
-        let err = conn.base_backup(&opts).unwrap_err();
-        assert!(err.to_string().contains("INCREMENTAL"), "{err}");
-    }
-
-    #[tokio::test]
     async fn test_read_slot_preflight_passes_on_pg16_then_hits_socket() {
         // READ_REPLICATION_SLOT is PG15+, so the PG16 preflight passes; the call
         // then fails at the null socket. Exercises the preflight line's Ok path.
         let mut conn = NativeConnection::null_for_testing();
         assert!(conn.read_replication_slot("s").is_err());
+    }
+
+    /// `null_for_testing` reports PG16, so the PG17 gate rejects UPLOAD_MANIFEST
+    /// before any socket I/O — the preflight's Err path.
+    #[tokio::test]
+    async fn test_upload_manifest_preflight_rejects_below_pg17() {
+        let mut conn = NativeConnection::null_for_testing();
+        let err = conn.upload_manifest(b"{}").unwrap_err();
+        assert!(err.to_string().contains("UPLOAD_MANIFEST"), "{err}");
+        assert!(err.to_string().contains("17+"), "{err}");
     }
 
     #[tokio::test]

--- a/src/connection/native/copy.rs
+++ b/src/connection/native/copy.rs
@@ -154,12 +154,15 @@ fn drain_read_buffer(
                 drained += 1;
             }
             b'E' => {
-                // ErrorResponse inside COPY mode — return as a protocol error
+                // ErrorResponse inside COPY mode — the server terminated the
+                // stream. Classify on SQLSTATE so an invalidated slot surfaces
+                // as a permanent error rather than a retryable protocol one.
                 let frame = read_buf.split_to(total_len);
                 let fields = super::error::parse_error_fields(&frame[5..]);
-                return Some(ReplicationError::protocol(format!(
-                    "server error during replication: {fields}"
-                )));
+                return Some(ReplicationError::from_sqlstate(
+                    &fields.code,
+                    format!("server error during replication: {fields}"),
+                ));
             }
             b'c' => {
                 // CopyDone — replication stream ended

--- a/src/connection/native/query.rs
+++ b/src/connection/native/query.rs
@@ -69,6 +69,7 @@ pub async fn simple_query<S: AsyncRead + AsyncWrite + Unpin>(
                 // ErrorResponse
                 let fields = super::error::parse_error_fields(&msg[5..]);
                 result.status = NativeResultStatus::FatalError;
+                result.error_code = Some(fields.code.clone());
                 result.error_msg = Some(format!("{}", fields));
                 // After an error, the server sends ReadyForQuery
                 // We need to consume it
@@ -85,6 +86,120 @@ pub async fn simple_query<S: AsyncRead + AsyncWrite + Unpin>(
     }
 
     Ok(result)
+}
+
+/// Largest payload put in a single CopyData frame.
+///
+/// A backup manifest is a few hundred KiB; the protocol would allow one frame,
+/// but chunking bounds the write buffer and keeps each message far below the
+/// server's 1 GiB message limit.
+const COPY_IN_CHUNK: usize = 64 * 1024;
+
+/// Execute a simple query that answers with `CopyInResponse ('G')`, stream
+/// `payload` into it, and collect the final result.
+///
+/// The only such replication command is `UPLOAD_MANIFEST`. The flow is
+/// `Query → CopyInResponse → CopyData* → CopyDone → CommandComplete →
+/// ReadyForQuery`, with `ErrorResponse` possible at either stage: the server
+/// rejects a malformed manifest only after the whole CopyIn completes, so the
+/// payload is always sent before the verdict is read.
+pub async fn simple_query_copy_in<S: AsyncRead + AsyncWrite + Unpin>(
+    stream: &mut S,
+    buf: &mut BytesMut,
+    sql: &str,
+    payload: &[u8],
+) -> Result<NativePgResult, ReplicationError> {
+    let query_msg = wire::build_query_message(sql);
+    wire::write_all(stream, &query_msg).await?;
+    wire::flush(stream).await?;
+
+    let mut result = NativePgResult::new();
+
+    // Phase 1: wait for the server to open the CopyIn.
+    loop {
+        let msg = wire::read_message(stream, buf).await?;
+        if msg.is_empty() {
+            continue;
+        }
+        match msg[0] {
+            b'G' => break, // CopyInResponse — the server is ready for data
+            b'E' => {
+                let fields = super::error::parse_error_fields(&msg[5..]);
+                result.status = NativeResultStatus::FatalError;
+                result.error_code = Some(fields.code.clone());
+                result.error_msg = Some(format!("{fields}"));
+                // The command never entered CopyIn; drain to ReadyForQuery so
+                // the connection stays usable.
+                drain_to_ready(stream, buf).await?;
+                return Ok(result);
+            }
+            b'N' => {
+                let fields = super::error::parse_error_fields(&msg[5..]);
+                tracing::info!("Server notice: {fields}");
+            }
+            b'Z' => {
+                return Err(ReplicationError::protocol(format!(
+                    "{sql} completed without entering CopyIn mode"
+                )));
+            }
+            other => {
+                tracing::debug!("Skipping message type '{}' before CopyIn", other as char);
+            }
+        }
+    }
+
+    // Phase 2: stream the payload, then close the copy.
+    for chunk in payload.chunks(COPY_IN_CHUNK) {
+        let msg = wire::build_copy_data(chunk);
+        wire::write_all(stream, &msg).await?;
+    }
+    let done = wire::build_copy_done();
+    wire::write_all(stream, &done).await?;
+    wire::flush(stream).await?;
+
+    // Phase 3: read the verdict.
+    loop {
+        let msg = wire::read_message(stream, buf).await?;
+        if msg.is_empty() {
+            continue;
+        }
+        match msg[0] {
+            b'C' => {
+                if result.status == NativeResultStatus::Empty {
+                    result.status = NativeResultStatus::CommandOk;
+                }
+            }
+            b'Z' => break,
+            b'E' => {
+                let fields = super::error::parse_error_fields(&msg[5..]);
+                result.status = NativeResultStatus::FatalError;
+                result.error_code = Some(fields.code.clone());
+                result.error_msg = Some(format!("{fields}"));
+            }
+            b'N' => {
+                let fields = super::error::parse_error_fields(&msg[5..]);
+                tracing::info!("Server notice: {fields}");
+            }
+            other => {
+                tracing::debug!("Skipping message type '{}' after CopyIn", other as char);
+            }
+        }
+    }
+
+    Ok(result)
+}
+
+/// Consume messages until `ReadyForQuery ('Z')`.
+async fn drain_to_ready<S: AsyncRead + AsyncWrite + Unpin>(
+    stream: &mut S,
+    buf: &mut BytesMut,
+) -> Result<(), ReplicationError> {
+    loop {
+        let msg = wire::read_message(stream, buf).await?;
+        if msg.first() == Some(&b'Z') {
+            return Ok(());
+        }
+    }
 }
 
 #[cfg(test)]
@@ -194,6 +309,257 @@ mod tests {
         msg.extend_from_slice(&len.to_be_bytes());
         msg.extend_from_slice(&payload);
         msg
+    }
+
+    /// Helper: build a CopyInResponse message ('G' + len + format + ncols)
+    fn build_copy_in_response() -> Vec<u8> {
+        let mut msg = vec![b'G'];
+        msg.extend_from_slice(&7i32.to_be_bytes());
+        msg.push(0); // overall format (text)
+        msg.extend_from_slice(&0i16.to_be_bytes()); // 0 columns
+        msg
+    }
+
+    /// Read everything the client sends until it goes quiet, so a test can
+    /// assert on the CopyData/CopyDoneframing it produced.
+    async fn drain_client<S: AsyncRead + AsyncWrite + Unpin>(
+        server: &mut S,
+        upto: usize,
+    ) -> Vec<u8> {
+        let mut got = Vec::new();
+        let mut chunk = vec![0u8; 8192];
+        while got.len() < upto {
+            match server.read(&mut chunk).await {
+                Ok(0) => break,
+                Ok(n) => got.extend_from_slice(&chunk[..n]),
+                Err(_) => break,
+            }
+        }
+        got
+    }
+
+    /// Happy path: Query -> CopyInResponse -> CopyData -> CopyDone ->
+    /// CommandComplete -> ReadyForQuery.
+    #[tokio::test]
+    async fn test_simple_query_copy_in_success() {
+        let (mut client, mut server) = tokio::io::duplex(65536);
+
+        let handle = tokio::spawn(async move {
+            // Query message, then open the CopyIn.
+            let mut discard = vec![0u8; 1024];
+            let _ = server.read(&mut discard).await;
+            server.write_all(&build_copy_in_response()).await.unwrap();
+            server.flush().await.unwrap();
+
+            // 'd' + len(4+7) + "payload", then 'c' + len(4).
+            let sent = drain_client(&mut server, 5 + 7 + 5).await;
+
+            server
+                .write_all(&build_command_complete("UPLOAD_MANIFEST"))
+                .await
+                .unwrap();
+            server
+                .write_all(&build_ready_for_query(b'I'))
+                .await
+                .unwrap();
+            server.flush().await.unwrap();
+            sent
+        });
+
+        let mut buf = BytesMut::new();
+        let result = simple_query_copy_in(&mut client, &mut buf, "UPLOAD_MANIFEST", b"payload")
+            .await
+            .unwrap();
+        assert_eq!(result.status(), &NativeResultStatus::CommandOk);
+        assert!(result.is_ok());
+
+        let sent = handle.await.unwrap();
+        // One CopyData frame carrying the payload, then CopyDone.
+        assert_eq!(sent[0], b'd');
+        assert_eq!(i32::from_be_bytes(sent[1..5].try_into().unwrap()), 4 + 7);
+        assert_eq!(&sent[5..12], b"payload");
+        assert_eq!(sent[12], b'c');
+        assert_eq!(i32::from_be_bytes(sent[13..17].try_into().unwrap()), 4);
+    }
+
+    /// A payload larger than COPY_IN_CHUNK is split across frames, and every
+    /// byte still arrives exactly once.
+    #[tokio::test]
+    async fn test_simple_query_copy_in_chunks_large_payload() {
+        let payload = vec![b'x'; COPY_IN_CHUNK + 100];
+        let expect_bytes = 2 * 5 + payload.len() + 5; // two CopyData headers + body + CopyDone
+        let (mut client, mut server) = tokio::io::duplex(4 * 1024 * 1024);
+
+        let handle = tokio::spawn(async move {
+            let mut discard = vec![0u8; 1024];
+            let _ = server.read(&mut discard).await;
+            server.write_all(&build_copy_in_response()).await.unwrap();
+            server.flush().await.unwrap();
+
+            let sent = drain_client(&mut server, expect_bytes).await;
+
+            server
+                .write_all(&build_command_complete("UPLOAD_MANIFEST"))
+                .await
+                .unwrap();
+            server
+                .write_all(&build_ready_for_query(b'I'))
+                .await
+                .unwrap();
+            server.flush().await.unwrap();
+            sent
+        });
+
+        let mut buf = BytesMut::new();
+        let result = simple_query_copy_in(&mut client, &mut buf, "UPLOAD_MANIFEST", &payload)
+            .await
+            .unwrap();
+        assert!(result.is_ok());
+
+        let sent = handle.await.unwrap();
+        let first = i32::from_be_bytes(sent[1..5].try_into().unwrap()) as usize - 4;
+        assert_eq!(first, COPY_IN_CHUNK, "first frame is a full chunk");
+        let second_at = 5 + first;
+        assert_eq!(sent[second_at], b'd');
+        let second =
+            i32::from_be_bytes(sent[second_at + 1..second_at + 5].try_into().unwrap()) as usize - 4;
+        assert_eq!(
+            first + second,
+            payload.len(),
+            "every byte sent exactly once"
+        );
+        assert_eq!(sent[second_at + 5 + second], b'c', "CopyDone follows");
+    }
+
+    /// The server rejects the command before opening the CopyIn (e.g.
+    /// UPLOAD_MANIFEST on PostgreSQL 16). The error must surface with its
+    /// SQLSTATE and the connection must be drained to ReadyForQuery.
+    #[tokio::test]
+    async fn test_simple_query_copy_in_error_before_copy_starts() {
+        let (mut client, mut server) = tokio::io::duplex(8192);
+
+        tokio::spawn(async move {
+            let mut discard = vec![0u8; 1024];
+            let _ = server.read(&mut discard).await;
+            server
+                .write_all(&build_error_response(
+                    "ERROR",
+                    "42601",
+                    "syntax error at or near \"UPLOAD_MANIFEST\"",
+                ))
+                .await
+                .unwrap();
+            server
+                .write_all(&build_ready_for_query(b'I'))
+                .await
+                .unwrap();
+            server.flush().await.unwrap();
+        });
+
+        let mut buf = BytesMut::new();
+        let result = simple_query_copy_in(&mut client, &mut buf, "UPLOAD_MANIFEST", b"x")
+            .await
+            .unwrap();
+        assert_eq!(result.status(), &NativeResultStatus::FatalError);
+        assert_eq!(result.error_sqlstate(), "42601");
+        assert!(result.error_message().unwrap().contains("syntax error"));
+    }
+
+    /// The manifest is only validated once the CopyIn completes, so the whole
+    /// payload goes out before the rejection arrives.
+    #[tokio::test]
+    async fn test_simple_query_copy_in_error_after_copy_completes() {
+        let (mut client, mut server) = tokio::io::duplex(8192);
+
+        tokio::spawn(async move {
+            let mut discard = vec![0u8; 1024];
+            let _ = server.read(&mut discard).await;
+            server.write_all(&build_copy_in_response()).await.unwrap();
+            server.flush().await.unwrap();
+
+            let _ = drain_client(&mut server, 5 + 3 + 5).await;
+
+            server
+                .write_all(&build_error_response(
+                    "ERROR",
+                    "XX000",
+                    "could not parse backup manifest",
+                ))
+                .await
+                .unwrap();
+            server
+                .write_all(&build_ready_for_query(b'I'))
+                .await
+                .unwrap();
+            server.flush().await.unwrap();
+        });
+
+        let mut buf = BytesMut::new();
+        let result = simple_query_copy_in(&mut client, &mut buf, "UPLOAD_MANIFEST", b"bad")
+            .await
+            .unwrap();
+        assert_eq!(result.status(), &NativeResultStatus::FatalError);
+        assert_eq!(result.error_sqlstate(), "XX000");
+        assert!(result.error_message().unwrap().contains("manifest"));
+    }
+
+    /// A NoticeResponse in either phase is logged and skipped, not mistaken for
+    /// the CopyIn opening or the final verdict.
+    #[tokio::test]
+    async fn test_simple_query_copy_in_skips_notices() {
+        let (mut client, mut server) = tokio::io::duplex(8192);
+
+        tokio::spawn(async move {
+            let mut discard = vec![0u8; 1024];
+            let _ = server.read(&mut discard).await;
+            let mut notice = build_error_response("NOTICE", "00000", "heads up");
+            notice[0] = b'N';
+            server.write_all(&notice).await.unwrap();
+            server.write_all(&build_copy_in_response()).await.unwrap();
+            server.flush().await.unwrap();
+
+            let _ = drain_client(&mut server, 5 + 1 + 5).await;
+
+            server.write_all(&notice).await.unwrap();
+            server
+                .write_all(&build_command_complete("UPLOAD_MANIFEST"))
+                .await
+                .unwrap();
+            server
+                .write_all(&build_ready_for_query(b'I'))
+                .await
+                .unwrap();
+            server.flush().await.unwrap();
+        });
+
+        let mut buf = BytesMut::new();
+        let result = simple_query_copy_in(&mut client, &mut buf, "UPLOAD_MANIFEST", b"m")
+            .await
+            .unwrap();
+        assert!(result.is_ok());
+    }
+
+    /// A server that answers with ReadyForQuery instead of opening the CopyIn is
+    /// a protocol violation, not a silent success.
+    #[tokio::test]
+    async fn test_simple_query_copy_in_never_enters_copy_mode() {
+        let (mut client, mut server) = tokio::io::duplex(8192);
+
+        tokio::spawn(async move {
+            let mut discard = vec![0u8; 1024];
+            let _ = server.read(&mut discard).await;
+            server
+                .write_all(&build_ready_for_query(b'I'))
+                .await
+                .unwrap();
+            server.flush().await.unwrap();
+        });
+
+        let mut buf = BytesMut::new();
+        let err = simple_query_copy_in(&mut client, &mut buf, "UPLOAD_MANIFEST", b"m")
+            .await
+            .unwrap_err();
+        assert!(err.to_string().contains("without entering CopyIn"), "{err}");
     }
 
     #[tokio::test]

--- a/src/connection/native/result.rs
+++ b/src/connection/native/result.rs
@@ -23,6 +23,7 @@ pub struct NativePgResult {
     pub(crate) columns: Vec<String>,
     pub(crate) rows: Vec<Vec<Option<Vec<u8>>>>,
     pub(crate) error_msg: Option<String>,
+    pub(crate) error_code: Option<String>,
 }
 
 impl NativePgResult {
@@ -32,6 +33,7 @@ impl NativePgResult {
             columns: Vec::new(),
             rows: Vec::new(),
             error_msg: None,
+            error_code: None,
         }
     }
 
@@ -84,6 +86,14 @@ impl NativePgResult {
     /// Get error message if any.
     pub fn error_message(&self) -> Option<String> {
         self.error_msg.clone()
+    }
+
+    /// The SQLSTATE of the failing `ErrorResponse`, or `""` when there was none.
+    ///
+    /// Mirrors the libpq backend's `PgResult::error_sqlstate`, so both backends
+    /// can feed `ReplicationError::from_sqlstate`. Crate-internal: `exec` maps every non-OK result to `Err`, so callers never hold a failing result.
+    pub(crate) fn error_sqlstate(&self) -> String {
+        self.error_code.clone().unwrap_or_default()
     }
 
     // ── Internal parsing helpers ─────────────────────────────────────────
@@ -202,6 +212,20 @@ mod tests {
         result.parse_data_row(&payload);
         assert_eq!(result.get_value(0, 0), Some("abc".to_string()));
         assert_eq!(result.get_value(0, 1), None);
+    }
+
+    /// The SQLSTATE survives onto the result, and an error-free result reports
+    /// an empty string rather than panicking.
+    #[test]
+    fn test_error_sqlstate() {
+        let mut r = NativePgResult::new();
+        assert_eq!(r.error_sqlstate(), "");
+
+        r.status = NativeResultStatus::FatalError;
+        r.error_code = Some("55000".to_string());
+        r.error_msg = Some("can no longer access replication slot".to_string());
+        assert_eq!(r.error_sqlstate(), "55000");
+        assert!(r.error_message().unwrap().contains("no longer"));
     }
 
     #[test]

--- a/src/connection/native/startup.rs
+++ b/src/connection/native/startup.rs
@@ -741,6 +741,17 @@ async fn startup_and_auth(
     Ok(server_version)
 }
 
+/// Leading ASCII-digit run of `s`, or 0. Pre-release servers report
+/// "19beta3"/"19rc1"/"19devel"; a plain `parse` yields 0 for those, which the
+/// caller's `< 140000` floor then rejects as "version 0".
+fn leading_num(s: &str) -> i32 {
+    s.split(|c: char| !c.is_ascii_digit())
+        .next()
+        .unwrap_or("")
+        .parse()
+        .unwrap_or(0)
+}
+
 /// Parse a server_version string like "16.1" or "16.1 (Debian 16.1-1)"
 /// into the integer format used by libpq (e.g. 160001).
 fn parse_server_version(version_str: &str) -> i32 {
@@ -750,21 +761,16 @@ fn parse_server_version(version_str: &str) -> i32 {
     let parts: Vec<&str> = version.split('.').collect();
     match parts.len() {
         1 => {
-            // e.g. "16" → 160000
-            parts[0].parse::<i32>().unwrap_or(0) * 10000
+            // e.g. "16" → 160000, "19beta3" → 190000
+            leading_num(parts[0]) * 10000
         }
         2 => {
             // e.g. "16.1" → 160001
-            let major = parts[0].parse::<i32>().unwrap_or(0);
-            let minor = parts[1].parse::<i32>().unwrap_or(0);
-            major * 10000 + minor
+            leading_num(parts[0]) * 10000 + leading_num(parts[1])
         }
         _ => {
             // e.g. "14.2.1" → 140201
-            let major = parts[0].parse::<i32>().unwrap_or(0);
-            let minor = parts[1].parse::<i32>().unwrap_or(0);
-            let patch = parts[2].parse::<i32>().unwrap_or(0);
-            major * 10000 + minor * 100 + patch
+            leading_num(parts[0]) * 10000 + leading_num(parts[1]) * 100 + leading_num(parts[2])
         }
     }
 }
@@ -825,6 +831,16 @@ mod tests {
             160004
         );
         assert_eq!(parse_server_version("16.12 - Azure"), 160012);
+    }
+
+    /// Pre-release servers report a non-numeric major ("19beta3"). These must
+    /// clear the 140000 floor, not parse to 0 and be rejected as unsupported.
+    #[test]
+    fn test_parse_server_version_prerelease() {
+        assert_eq!(parse_server_version("19beta3"), 190000);
+        assert_eq!(parse_server_version("19rc1"), 190000);
+        assert_eq!(parse_server_version("19devel"), 190000);
+        assert_eq!(parse_server_version("18beta1 (Debian 18~beta1-1)"), 180000);
     }
 
     #[test]

--- a/src/deserializer.rs
+++ b/src/deserializer.rs
@@ -1951,7 +1951,8 @@ mod tests {
 
     #[test]
     fn test_deserialize_data_truncate_errors() {
-        let event = ChangeEvent::truncate(vec![Arc::from("public.users")], Lsn::new(100));
+        let event =
+            ChangeEvent::truncate(vec![Arc::from("public.users")], false, false, Lsn::new(100));
         let result: crate::error::Result<UserModel> = event.deserialize_data();
         assert!(result.is_err());
         let msg = result.unwrap_err().to_string();
@@ -3462,7 +3463,7 @@ mod tests {
         let commit = ChangeEvent::commit(ts, Lsn::new(5), Lsn::new(5), Lsn::new(6));
         assert_eq!(commit.event_type_str(), "commit");
 
-        let truncate = ChangeEvent::truncate(vec![Arc::from("t")], Lsn::new(7));
+        let truncate = ChangeEvent::truncate(vec![Arc::from("t")], false, false, Lsn::new(7));
         assert_eq!(truncate.event_type_str(), "truncate");
     }
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -153,6 +153,39 @@ impl ReplicationError {
         ReplicationError::ReplicationSlot(msg.into())
     }
 
+    /// Classify a server error by its SQLSTATE.
+    ///
+    /// Only the two codes that are unambiguously terminal for a replication
+    /// slot are promoted to [`ReplicationSlot`](Self::ReplicationSlot) (which
+    /// [`is_permanent`](Self::is_permanent) reports as `true`, stopping the
+    /// retry loop); everything else stays `Protocol` so the streaming layer
+    /// keeps retrying:
+    ///
+    /// - `55000` *object_not_in_prerequisite_state* — the slot was invalidated
+    ///   (`wal_removed`, `rows_removed`, `wal_level_insufficient`, or PG18's
+    ///   `idle_timeout`), or `wal_level` is below `logical`. Recovery requires
+    ///   dropping the slot and re-syncing; retrying cannot help.
+    /// - `42704` *undefined_object* — the slot does not exist.
+    ///
+    /// Match on the code rather than the message: PostgreSQL 18 reworded slot
+    /// invalidation from "can no longer get changes from" to "can no longer
+    /// access", but the SQLSTATE is stable across major versions.
+    ///
+    /// An empty `sqlstate` (no diagnostics available) yields a plain `Protocol`
+    /// error with no prefix.
+    ///
+    /// Crate-internal, and gated on a connection backend for the same reason as
+    /// [`Self::stream_stopped`]: only the backends parse server diagnostics.
+    #[cfg(any(feature = "libpq", feature = "rustls-tls"))]
+    pub(crate) fn from_sqlstate<S: Into<String>>(sqlstate: &str, msg: S) -> Self {
+        let msg = msg.into();
+        match sqlstate {
+            "" => ReplicationError::Protocol(msg),
+            "55000" | "42704" => ReplicationError::ReplicationSlot(format!("[{sqlstate}] {msg}")),
+            _ => ReplicationError::Protocol(format!("[{sqlstate}] {msg}")),
+        }
+    }
+
     /// Create a new timeout error
     pub fn timeout<S: Into<String>>(msg: S) -> Self {
         ReplicationError::Timeout(msg.into())
@@ -182,8 +215,8 @@ impl ReplicationError {
     ///
     /// Crate-internal: the library emits this; external consumers match the [`ReplicationError::StreamStopped`] variant rather than constructing it.
     ///
-    /// Gated on a connection backend: the streaming layer that emits it  (`crate::stream`) is compiled only with `libpq`/`rustls-tls`, so this helper is dead code in the parser-only `no_std` build without the gate.
-    #[cfg(feature = "std")]
+    /// Gated on a connection backend: the streaming layer that emits it  (`crate::stream`) is compiled only with `libpq`/`rustls-tls`, so this helper is dead code in any build without one — including `--features std` on its own.
+    #[cfg(any(feature = "libpq", feature = "rustls-tls"))]
     pub(crate) fn stream_stopped(lsn: Lsn) -> Self {
         ReplicationError::StreamStopped(lsn)
     }
@@ -223,7 +256,7 @@ impl ReplicationError {
     /// Check if the error is the terminal bounded-replay stop signal.
     ///
     /// Gated on a connection backend for the same reason as [`Self::stream_stopped`]: its only caller lives in the backend-gated `crate::stream`.
-    #[cfg(feature = "std")]
+    #[cfg(any(feature = "libpq", feature = "rustls-tls"))]
     pub(crate) fn is_stream_stopped(&self) -> bool {
         matches!(self, ReplicationError::StreamStopped(_))
     }
@@ -498,6 +531,44 @@ mod tests {
 mod stop_signal_tests {
     use super::*;
     use crate::types::Lsn;
+
+    /// The two slot-fatal SQLSTATEs must become permanent errors so the retry
+    /// loop gives up instead of reconnecting into the same dead slot.
+    #[test]
+    fn test_from_sqlstate_slot_fatal_is_permanent() {
+        for code in ["55000", "42704"] {
+            let err = ReplicationError::from_sqlstate(code, "can no longer access slot");
+            assert!(
+                matches!(err, ReplicationError::ReplicationSlot(_)),
+                "{code} should map to ReplicationSlot, got {err:?}"
+            );
+            assert!(err.is_permanent(), "{code} should be permanent");
+            assert!(err.to_string().contains(code), "{err}");
+        }
+    }
+
+    /// Everything else stays retryable — a busy slot (55006) or a transient
+    /// server hiccup must not be mistaken for a dead slot.
+    #[test]
+    fn test_from_sqlstate_other_codes_stay_retryable() {
+        for code in ["55006", "57P01", "53300"] {
+            let err = ReplicationError::from_sqlstate(code, "boom");
+            assert!(
+                matches!(err, ReplicationError::Protocol(_)),
+                "{code} should stay Protocol, got {err:?}"
+            );
+            assert!(!err.is_permanent(), "{code} should not be permanent");
+            assert!(err.to_string().contains(code), "{err}");
+        }
+    }
+
+    /// No diagnostics available: no empty `[]` prefix in the message.
+    #[test]
+    fn test_from_sqlstate_empty_code() {
+        let err = ReplicationError::from_sqlstate("", "connection reset");
+        assert!(matches!(err, ReplicationError::Protocol(_)));
+        assert!(!err.to_string().contains('['), "{err}");
+    }
 
     #[test]
     fn stream_stopped_is_terminal_not_retryable() {

--- a/src/protocol.rs
+++ b/src/protocol.rs
@@ -693,6 +693,21 @@ impl LogicalReplicationParser {
         self.streaming_context.is_some()
     }
 
+    /// Drop any in-progress streaming-transaction context.
+    ///
+    /// Call this after re-issuing `START_REPLICATION` on a new connection. A
+    /// `StreamStart`/`StreamStop` pair can straddle a disconnect, and the server
+    /// resumes from a transaction boundary — but a parser still holding the
+    /// context would read a phantom xid prefix off every subsequent message.
+    ///
+    /// Crate-internal: the only caller is the backend-gated stream layer, which
+    /// is also the only thing that reconnects.
+    #[cfg(any(feature = "libpq", feature = "rustls-tls"))]
+    #[inline]
+    pub(crate) fn reset(&mut self) {
+        self.streaming_context = None;
+    }
+
     /// Parse a WAL data message from the replication stream
     #[inline]
     pub fn parse_wal_message(&mut self, data: &[u8]) -> Result<StreamingReplicationMessage> {
@@ -1425,9 +1440,10 @@ pub(crate) fn message_to_change_event(
             replica_identity,
             columns,
         } => {
-            // Detect schema changes: if we already have this relation cached
-            // and the schema differs, emit a Relation event before updating.
-            let schema_changed = if let Some(existing) = state.get_relation(relation_id) {
+            // Emit a Relation event the first time a table is seen and whenever
+            // its schema changes; stay silent for the identical repeats pgoutput
+            // sends at the start of every transaction.
+            let emit = if let Some(existing) = state.get_relation(relation_id) {
                 existing.namespace.as_ref() != namespace.as_ref()
                     || existing.relation_name.as_ref() != relation_name.as_ref()
                     || existing.replica_identity != replica_identity
@@ -1439,10 +1455,10 @@ pub(crate) fn message_to_change_event(
                             || a.is_key() != b.is_key()
                     })
             } else {
-                false
+                true
             };
 
-            if schema_changed {
+            if emit {
                 let ri = ReplicaIdentity::from_byte(replica_identity)
                     .unwrap_or(ReplicaIdentity::Default);
                 let relation_columns = columns
@@ -1621,7 +1637,11 @@ pub(crate) fn message_to_change_event(
             }
 
             ChangeEvent {
-                event_type: EventType::Truncate(truncate_tables),
+                event_type: EventType::Truncate {
+                    tables: truncate_tables,
+                    cascade: flags & 1 != 0,
+                    restart_identity: flags & 2 != 0,
+                },
                 lsn: Lsn::new(lsn),
                 metadata: None,
             }
@@ -2019,7 +2039,7 @@ pub fn build_hot_standby_feedback_message(
 /// - Int64: applied LSN (last WAL byte replayed)
 /// - Int64: client timestamp
 /// - Byte1: 1 to request an immediate server reply, else 0
-#[cfg(feature = "std")]
+#[cfg(any(feature = "libpq", feature = "rustls-tls"))]
 pub(crate) fn build_standby_status_update_message(
     received_lsn: XLogRecPtr,
     flushed_lsn: XLogRecPtr,
@@ -2120,8 +2140,8 @@ mod tests {
             }
         }
 
-        // The leading Relation only populated the cache; data messages that
-        // followed produced events, so the relation must be cached.
+        // The leading Relation populated the cache and emitted an event; the
+        // data messages that followed produced events off that cache.
         assert!(decoder.state().get_relation(42).is_some());
 
         // Concrete decode of the Insert, independent of the reference path.
@@ -2132,8 +2152,8 @@ mod tests {
                 Lsn::new(0x10),
             )
             .unwrap()
-            .is_none(),
-            "first Relation is a cache update, not an event"
+            .is_some(),
+            "first Relation emits an event and caches the schema"
         );
         let ev = d
             .decode_message(
@@ -2230,10 +2250,52 @@ mod tests {
             .expect("truncate yields an event");
         assert_eq!(ev.lsn, Lsn::new(0x50));
         match ev.event_type {
-            EventType::Truncate(ref tables) => {
+            EventType::Truncate { ref tables, .. } => {
                 assert_eq!(tables, &vec![Arc::from("public.users")]);
             }
             ref other => panic!("expected Truncate, got {other:?}"),
+        }
+    }
+
+    /// TRUNCATE's option byte reaches the user event: 1 = CASCADE,
+    /// 2 = RESTART IDENTITY. A sink needs both to reproduce the statement.
+    #[test]
+    fn test_truncate_flags_reach_change_event() {
+        for (flags, cascade, restart) in [
+            (0u8, false, false),
+            (1, true, false),
+            (2, false, true),
+            (3, true, true),
+        ] {
+            let mut state = ReplicationState::new();
+            state.add_relation(RelationInfo::new(
+                7,
+                Arc::from("public"),
+                Arc::from("t"),
+                b'd',
+                vec![ColumnInfo::new(1, "id".to_string(), 23, -1)],
+            ));
+
+            let msg = StreamingReplicationMessage::new(LogicalReplicationMessage::Truncate {
+                relation_ids: vec![7],
+                flags,
+            });
+            let ev = message_to_change_event(&mut state, msg, 0x900)
+                .unwrap()
+                .expect("truncate yields an event");
+
+            match ev.event_type {
+                EventType::Truncate {
+                    ref tables,
+                    cascade: c,
+                    restart_identity: r,
+                } => {
+                    assert_eq!(tables, &vec![Arc::<str>::from("public.t")]);
+                    assert_eq!(c, cascade, "cascade for flags={flags}");
+                    assert_eq!(r, restart, "restart_identity for flags={flags}");
+                }
+                ref other => panic!("expected Truncate, got {other:?}"),
+            }
         }
     }
 
@@ -2792,6 +2854,7 @@ mod tests {
         assert_eq!(catalog_xmin_epoch, 2);
     }
 
+    #[cfg(any(feature = "libpq", feature = "rustls-tls"))]
     #[test]
     fn test_build_standby_status_update_message() {
         let message =
@@ -3426,6 +3489,42 @@ mod tests {
         let result = parser.parse_wal_message(&data).unwrap();
         assert!(result.is_streaming);
         assert_eq!(result.xid, Some(42));
+        match result.message {
+            LogicalReplicationMessage::Insert { relation_id, .. } => {
+                assert_eq!(relation_id, 12345);
+            }
+            _ => panic!("Expected Insert"),
+        }
+    }
+
+    /// A disconnect can land between StreamStart and StreamStop. After
+    /// reconnecting, the server resumes at a transaction boundary, so a parser
+    /// still holding the context would eat 4 bytes of the next message body as
+    /// a phantom xid — silently corrupting the relation cache.
+    #[cfg(any(feature = "libpq", feature = "rustls-tls"))]
+    #[test]
+    fn test_reset_clears_streaming_context() {
+        let mut parser = LogicalReplicationParser::with_protocol_version(2);
+
+        let mut stream_start = vec![message_types::STREAM_START];
+        stream_start.extend_from_slice(&write_u32_be(42)); // xid
+        stream_start.push(0x01); // first_segment
+        let _ = parser.parse_wal_message(&stream_start).unwrap();
+
+        parser.reset();
+
+        // No xid prefix now — relation_id must be read from offset 1.
+        let mut data = vec![message_types::INSERT];
+        data.extend_from_slice(&write_u32_be(12345)); // relation_id
+        data.push(b'N');
+        data.extend_from_slice(&[0x00, 0x01]); // 1 column
+        data.push(b't');
+        data.extend_from_slice(&write_u32_be(4));
+        data.extend_from_slice(b"test");
+
+        let result = parser.parse_wal_message(&data).unwrap();
+        assert!(!result.is_streaming);
+        assert_eq!(result.xid, None);
         match result.message {
             LogicalReplicationMessage::Insert { relation_id, .. } => {
                 assert_eq!(relation_id, 12345);

--- a/src/sql_builder.rs
+++ b/src/sql_builder.rs
@@ -459,7 +459,10 @@ pub fn build_start_physical_replication_sql(
 /// # Compatibility
 ///
 /// This emits the PostgreSQL 15+ parenthesized generic-option form
-/// (`BASE_BACKUP (LABEL '…', …)`). PostgreSQL 14 used a different positional  grammar with different keywords (`FAST`, `NOWAIT`, `NOVERIFY_CHECKSUMS`, …), so this builder is **not** compatible with PostgreSQL 14. The `incremental` option additionally requires PostgreSQL 17+. Matching options to the server version is the caller's responsibility.
+/// (`BASE_BACKUP (LABEL '…', …)`). PostgreSQL 14 used a different positional  grammar with different keywords (`FAST`, `NOWAIT`, `NOVERIFY_CHECKSUMS`, …), so this builder is **not** compatible with PostgreSQL 14. Matching options to the server version is the caller's responsibility.
+///
+/// `INCREMENTAL` requires PostgreSQL 17+ **and** a prior `UPLOAD_MANIFEST` on
+/// the same connection (see `PgReplicationConnection::upload_manifest`).
 ///
 /// # Example
 ///
@@ -621,6 +624,20 @@ mod version_preflight {
         if server_version != 0 && server_version < PG15 {
             return Err(ReplicationError::config(format!(
                 "READ_REPLICATION_SLOT requires PostgreSQL 15+, but the server reports {}",
+                format_server_version(server_version)
+            )));
+        }
+        Ok(())
+    }
+
+    /// Preflight `UPLOAD_MANIFEST` against the server version.
+    ///
+    /// Gate: the command was added alongside incremental backup in PostgreSQL 17.
+    /// `server_version == 0` (unknown) passes.
+    pub(crate) fn check_upload_manifest_version(server_version: i32) -> Result<()> {
+        if server_version != 0 && server_version < PG17 {
+            return Err(ReplicationError::config(format!(
+                "UPLOAD_MANIFEST requires PostgreSQL 17+, but the server reports {}",
                 format_server_version(server_version)
             )));
         }
@@ -821,6 +838,17 @@ mod version_preflight {
         }
 
         #[test]
+        fn preflight_upload_manifest_requires_pg17() {
+            let err = check_upload_manifest_version(160000).unwrap_err();
+            assert!(err.to_string().contains("UPLOAD_MANIFEST"), "{err}");
+            assert!(err.to_string().contains("17+"), "{err}");
+            assert!(check_upload_manifest_version(170000).is_ok());
+            assert!(check_upload_manifest_version(180000).is_ok());
+            // Unknown version passes; the server gets the final say.
+            assert!(check_upload_manifest_version(0).is_ok());
+        }
+
+        #[test]
         fn prepare_base_backup_builds_and_gates() {
             // Unknown version (0) passes preflight and builds a bare BASE_BACKUP.
             let sql = prepare_base_backup(0, &BaseBackupOptions::default()).unwrap();
@@ -846,7 +874,8 @@ mod version_preflight {
 
 #[cfg(any(feature = "libpq", feature = "rustls-tls"))]
 pub(crate) use version_preflight::{
-    prepare_alter_slot, prepare_base_backup, prepare_create_slot, prepare_read_slot,
+    check_upload_manifest_version, prepare_alter_slot, prepare_base_backup, prepare_create_slot,
+    prepare_read_slot,
 };
 
 /// Options for building a `CREATE SUBSCRIPTION` SQL statement.
@@ -1839,18 +1868,6 @@ mod tests {
     }
 
     #[test]
-    fn base_backup_incremental() {
-        let opts = BaseBackupOptions {
-            incremental: true,
-            ..Default::default()
-        };
-        assert_eq!(
-            build_base_backup_sql(&opts).unwrap(),
-            "BASE_BACKUP (INCREMENTAL)"
-        );
-    }
-
-    #[test]
     fn base_backup_multiple_options() {
         let opts = BaseBackupOptions {
             label: Some("backup".to_string()),
@@ -1862,6 +1879,18 @@ mod tests {
         assert_eq!(
             build_base_backup_sql(&opts).unwrap(),
             "BASE_BACKUP (LABEL 'backup', PROGRESS true, WAL true, VERIFY_CHECKSUMS true)"
+        );
+    }
+
+    #[test]
+    fn base_backup_incremental() {
+        let opts = BaseBackupOptions {
+            incremental: true,
+            ..Default::default()
+        };
+        assert_eq!(
+            build_base_backup_sql(&opts).unwrap(),
+            "BASE_BACKUP (INCREMENTAL)"
         );
     }
 

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -82,6 +82,9 @@ const HEALTH_CHECK_EVENT_INTERVAL: u32 = 1024;
 #[derive(Debug, Clone)]
 pub struct ReplicationStreamConfig {
     pub slot_name: String,
+    /// Publication to replicate from.
+    ///
+    /// To stream from several publications at once, pass them comma-separated  with each name quoted — `r#"pub_a","pub_b"#` — which produces the `publication_names '"pub_a","pub_b"'` list pgoutput expects. One stream and one slot cover all of them.
     pub publication_name: String,
     pub protocol_version: u32,
     pub streaming_mode: StreamingMode,
@@ -892,6 +895,10 @@ impl LogicalReplicationStream {
 
         self.connection
             .start_replication(&self.config.slot_name, last_lsn, &options_ref)?;
+
+        // The server resumes at a transaction boundary, so a StreamStart seen
+        // before the disconnect has no matching StreamStop coming.
+        self.parser.reset();
 
         info!("Replication connection recovered and restarted");
         Ok(())
@@ -4288,9 +4295,18 @@ mod tests {
 
         let result =
             crate::protocol::message_to_change_event(&mut stream.state, msg, 0x500).unwrap();
-        // Relation messages return None (they update internal state)
-        assert!(result.is_none());
-        // But the relation should be stored in state
+        // A first sighting emits a Relation event and caches the schema.
+        match result.expect("first Relation emits an event").event_type {
+            EventType::Relation {
+                relation_id,
+                relation_name,
+                ..
+            } => {
+                assert_eq!(relation_id, 100);
+                assert_eq!(&*relation_name, "test_table");
+            }
+            other => panic!("Expected Relation event, got {other:?}"),
+        }
         assert!(stream.state.get_relation(100).is_some());
     }
 
@@ -4529,7 +4545,7 @@ mod tests {
         assert!(result.is_some());
         let event = result.unwrap();
         match event.event_type {
-            EventType::Truncate(tables) => {
+            EventType::Truncate { tables, .. } => {
                 assert_eq!(tables.len(), 1); // Only known relation
                 assert_eq!(&*tables[0], "public.users");
             }
@@ -4957,7 +4973,7 @@ mod tests {
 
         let wal = build_wal_message(0x1000, 0x1100, &rel_payload);
         let result = stream.process_wal_message(wal).unwrap();
-        assert!(result.is_none()); // Relation => None
+        assert!(result.is_some()); // First sighting of a relation emits an event
         assert!(stream.state.get_relation(100).is_some());
 
         // Now build an Insert payload: 'I' + relation_id(4) + 'N' + ncols(2) + columns
@@ -5312,7 +5328,7 @@ mod tests {
             crate::protocol::message_to_change_event(&mut stream.state, msg, 0x500).unwrap();
         assert!(result.is_some());
         match result.unwrap().event_type {
-            EventType::Truncate(tables) => {
+            EventType::Truncate { tables, .. } => {
                 assert!(tables.is_empty());
             }
             _ => panic!("Expected Truncate event"),
@@ -6950,7 +6966,7 @@ mod tests {
 
         let wal = Bytes::from(build_wal_message(0x1000, 0x1500, &rel_payload));
         let result = stream.process_wal_message(wal).unwrap();
-        assert!(result.is_none()); // Relation messages don't produce events
+        assert!(result.is_some()); // First sighting of a relation emits an event
 
         // Build Insert payload
         let mut ins_payload = Vec::new();
@@ -8002,31 +8018,37 @@ mod tests {
     // ================================================================
 
     #[test]
-    fn test_convert_to_change_event_relation_first_time_returns_none() {
+    fn test_convert_to_change_event_relation_first_time_emits_then_dedups() {
         use crate::protocol::ColumnInfo;
         use crate::{LogicalReplicationMessage, StreamingReplicationMessage};
 
         let config = create_test_config();
         let mut stream = create_test_stream(config);
 
-        // First time seeing this relation — should cache it and return None
-        let msg = StreamingReplicationMessage::new(LogicalReplicationMessage::Relation {
-            relation_id: 200,
-            namespace: Arc::from("public"),
-            relation_name: Arc::from("orders"),
-            replica_identity: b'd',
-            columns: vec![
-                ColumnInfo::new(1, "id".to_string(), 23, -1),
-                ColumnInfo::new(0, "total".to_string(), 1700, -1),
-            ],
-        });
+        let mk = || {
+            StreamingReplicationMessage::new(LogicalReplicationMessage::Relation {
+                relation_id: 200,
+                namespace: Arc::from("public"),
+                relation_name: Arc::from("orders"),
+                replica_identity: b'd',
+                columns: vec![
+                    ColumnInfo::new(1, "id".to_string(), 23, -1),
+                    ColumnInfo::new(0, "total".to_string(), 1700, -1),
+                ],
+            })
+        };
 
-        let result =
-            crate::protocol::message_to_change_event(&mut stream.state, msg, 0xB000).unwrap();
-        assert!(result.is_none(), "First-time relation should return None");
-
-        // Verify it was cached
+        // First sighting: emit, and cache the schema.
+        let first =
+            crate::protocol::message_to_change_event(&mut stream.state, mk(), 0xB000).unwrap();
+        assert!(first.is_some(), "First-time relation should emit an event");
         assert!(stream.state.get_relation(200).is_some());
+
+        // pgoutput repeats Relation at the start of every transaction; an
+        // unchanged repeat must stay silent.
+        let repeat =
+            crate::protocol::message_to_change_event(&mut stream.state, mk(), 0xB100).unwrap();
+        assert!(repeat.is_none(), "Unchanged repeat should return None");
     }
 
     #[test]

--- a/src/types.rs
+++ b/src/types.rs
@@ -400,7 +400,12 @@ pub struct BaseBackupOptions {
     /// Manifest checksum algorithm: 'NONE', 'CRC32C', 'SHA224', 'SHA256', 'SHA384', 'SHA512'
     pub manifest_checksums: Option<String>,
 
-    /// Request an incremental backup
+    /// Request an incremental backup (PostgreSQL 17+).
+    ///
+    /// Only legal after `upload_manifest()` has been called on the **same**
+    /// connection with the `backup_manifest` of the prior full backup; the
+    /// server otherwise answers `must UPLOAD_MANIFEST before performing an
+    /// incremental BASE_BACKUP`. The server must also have `summarize_wal = on`.
     pub incremental: bool,
 }
 
@@ -508,7 +513,18 @@ pub enum EventType {
         replica_identity: ReplicaIdentity,
         key_columns: Vec<Arc<str>>,
     },
-    Truncate(Vec<Arc<str>>),
+    /// One or more tables were truncated.
+    ///
+    /// PostgreSQL expands `CASCADE` before writing WAL, so `tables` already
+    /// lists every published relation that was emptied. The flags say how the
+    /// origin statement was written, which a sink needs to reproduce it:
+    /// `cascade` to clear dependants on the target, `restart_identity` to reset
+    /// its sequences.
+    Truncate {
+        tables: Vec<Arc<str>>,
+        cascade: bool,
+        restart_identity: bool,
+    },
     Begin {
         transaction_id: u32,
         final_lsn: Lsn,
@@ -872,10 +888,21 @@ impl ChangeEvent {
     /// # Arguments
     ///
     /// * `tables` - List of table names that were truncated
+    /// * `cascade` - The origin statement carried `CASCADE`
+    /// * `restart_identity` - The origin statement carried `RESTART IDENTITY`
     /// * `lsn` - Log Sequence Number for this event
-    pub fn truncate(tables: Vec<Arc<str>>, lsn: Lsn) -> Self {
+    pub fn truncate(
+        tables: Vec<Arc<str>>,
+        cascade: bool,
+        restart_identity: bool,
+        lsn: Lsn,
+    ) -> Self {
         Self {
-            event_type: EventType::Truncate(tables),
+            event_type: EventType::Truncate {
+                tables,
+                cascade,
+                restart_identity,
+            },
             lsn,
             metadata: None,
         }
@@ -1269,7 +1296,7 @@ impl ChangeEvent {
             EventType::Insert { .. } => "insert",
             EventType::Update { .. } => "update",
             EventType::Delete { .. } => "delete",
-            EventType::Truncate(_) => "truncate",
+            EventType::Truncate { .. } => "truncate",
             EventType::Begin { .. } => "begin",
             EventType::Commit { .. } => "commit",
             EventType::StreamStart { .. } => "stream_start",
@@ -1388,8 +1415,15 @@ impl ChangeEvent {
                     encode_arc_str(buf, kc);
                 }
             }
-            EventType::Truncate(tables) => {
+            EventType::Truncate {
+                tables,
+                cascade,
+                restart_identity,
+            } => {
                 buf.extend_from_slice(&[message_types::TRUNCATE]);
+                // Same flag bits pgoutput uses: 1 = CASCADE, 2 = RESTART IDENTITY.
+                let flags = u8::from(*cascade) | (u8::from(*restart_identity) << 1);
+                buf.extend_from_slice(&[flags]);
                 buf.extend_from_slice(&(tables.len() as u16).to_be_bytes());
                 for t in tables {
                     encode_arc_str(buf, t);
@@ -1695,12 +1729,17 @@ impl ChangeEvent {
                 }
             }
             message_types::TRUNCATE => {
+                let flags = reader.read_u8()?;
                 let count = reader.read_u16()? as usize;
                 let mut tables = Vec::with_capacity(count);
                 for _ in 0..count {
                     tables.push(decode_arc_str(&mut reader)?);
                 }
-                EventType::Truncate(tables)
+                EventType::Truncate {
+                    tables,
+                    cascade: flags & 1 != 0,
+                    restart_identity: flags & 2 != 0,
+                }
             }
             message_types::BEGIN => {
                 let transaction_id = reader.read_u32()?;
@@ -2322,12 +2361,18 @@ mod tests {
     #[test]
     fn test_change_event_truncate() {
         let tables: Vec<Arc<str>> = vec![Arc::from("public.users"), Arc::from("public.orders")];
-        let event = ChangeEvent::truncate(tables.clone(), Lsn::new(7000));
+        let event = ChangeEvent::truncate(tables.clone(), true, true, Lsn::new(7000));
 
         assert_eq!(event.lsn.value(), 7000);
         match &event.event_type {
-            EventType::Truncate(t) => {
+            EventType::Truncate {
+                tables: t,
+                cascade,
+                restart_identity,
+            } => {
                 assert_eq!(t, &tables);
+                assert!(cascade);
+                assert!(restart_identity);
             }
             _ => panic!("Expected Truncate event"),
         }
@@ -2435,7 +2480,7 @@ mod tests {
         assert_eq!(keys, &vec![Arc::<str>::from("id")]);
 
         // Truncate has no key_columns
-        let truncate = ChangeEvent::truncate(vec![], Lsn::new(400));
+        let truncate = ChangeEvent::truncate(vec![], false, false, Lsn::new(400));
         assert!(truncate.get_key_columns().is_none());
 
         // Begin has no key_columns
@@ -2511,7 +2556,7 @@ mod tests {
         );
         assert_eq!(delete.event_type_str(), "delete");
 
-        let truncate = ChangeEvent::truncate(vec![Arc::from("t")], Lsn::new(400));
+        let truncate = ChangeEvent::truncate(vec![Arc::from("t")], false, false, Lsn::new(400));
         assert_eq!(truncate.event_type_str(), "truncate");
 
         // "other" for Begin, Commit, Relation, Type, Origin, Message
@@ -2707,13 +2752,13 @@ mod tests {
     #[test]
     fn test_encode_decode_truncate() {
         let tables = vec![Arc::from("public.a"), Arc::from("public.b")];
-        let event = ChangeEvent::truncate(tables, Lsn::new(4000));
+        let event = ChangeEvent::truncate(tables, true, false, Lsn::new(4000));
         assert_encode_decode_round_trip(&event);
     }
 
     #[test]
     fn test_encode_decode_truncate_empty() {
-        let event = ChangeEvent::truncate(vec![], Lsn::new(4100));
+        let event = ChangeEvent::truncate(vec![], false, true, Lsn::new(4100));
         assert_encode_decode_round_trip(&event);
     }
 
@@ -3184,7 +3229,11 @@ mod tests {
                 replica_identity: ReplicaIdentity::Default,
                 key_columns: vec![],
             },
-            EventType::Truncate(vec![]),
+            EventType::Truncate {
+                tables: vec![],
+                cascade: false,
+                restart_identity: false,
+            },
             EventType::Begin {
                 transaction_id: 1,
                 final_lsn: Lsn::new(1),


### PR DESCRIPTION
## Summary

  Fixes two silent-data-corruption bugs in the replication client, makes replication-slot failures type-matchable, and completes BaseBackupOptions::incremental — an option that was exposed but could never succeed.

  The work started as an investigation into what PostgreSQL 18/19 added to the replication protocol. The answer was nothing client-visible: LOGICALREP_PROTO_MAX_VERSION_NUM is still 4
  from REL_16 through master (there is no proto_version 5), the 19 LogicalRepMsgType tags have been byte-identical since PG15, and pgoutput has accepted the same 7 options since PG16. A
  word-for-word diff of §54.9 between PG17 and PG18 shows no protocol change (corroborated by Debezium's "support PG18" PR, which touched only CI config and no Java source). PG19 adds
  two COPY-BOTH tags 's'/'p', but they are strict request/response — a client that never sends 'p' never receives 's', and unknown tags are already warn-and-dropped.

  Silent corruption (both would return Ok with wrong data or a clean-looking exit):
  - The parser's streaming context was never cleared on reconnect. recover_connection() rebuilt the connection but never touched self.parser, so disconnecting between StreamStart and
  StreamStop — i.e. mid-way through a large transaction, precisely when the server is busiest — left the parser eating four bytes of every later message body as a phantom xid. Observed:
  relation OID 16384 decoded as 1886741100 and namespace "public" as "ic", returned as Ok, poisoning the relation cache permanently.
  - parse_server_version rejected every pre-release server: "19beta3" / "19rc1" / "19devel" parsed to 0 and were then refused by the PG14+ floor as "PostgreSQL version 0 is not 
  supported". Since the default backend is rustls-tls, this blocked all beta/rc compatibility testing on the default build path.

  Error classification: both backends discarded the server's SQLSTATE, so an invalidated replication slot (wal_removed, rows_removed, wal_level_insufficient, PG18's idle_timeout) was indistinguishable from a transient hiccup. Consumers had to string-match an error message whose wording changed in PG18 ("can no longer get changes from" → "can no longer access"). A shared ReplicationError::from_sqlstate now promotes only 55000 and 42704 to ReplicationSlot (which is_permanent() reports as true, stopping the retry loop). 55006 (slot busy) is deliberately not promoted — it is genuinely transient.

  Backend parity: libpq mapped PQgetCopyData == -1 straight to CopyDone without calling PQgetResult, so pg_terminate_backend, a wal_sender_timeout expiry, or a slot invalidation all
  surfaced as ReplicationError::Cancelled — the same variant as user cancellation, which for_each_event and WalRouter::run_over treat as a graceful exit. A consumer would stop with no
  error, no log, and no metric. The rustls-tls backend already handled this correctly. Cancelled is now reserved for the cancellation-token path.

  New capability: upload_manifest() on both backends implements UPLOAD_MANIFEST (PG17+), the only walsender command that answers with CopyInResponse. This is the prerequisite for
  BaseBackupOptions::incremental, which previously emitted valid INCREMENTAL SQL that the server rejected 100% of the time because no way to upload a manifest existed.


  Related issues

  n/a — no tracking issue; found during a protocol-gap audit.

  Type of change

  - [x] Bug fix
  - [x] New feature
  - [ ] Performance improvement
  - [x] Refactor / internal cleanup
  - [x] Documentation
  - [x] CI / build

  Checklist

  - [x] make before-git-push passes locally (check, build, format, audit, test, doc-check)
  - [x] Tests added/updated for the change (coverage stays ≥ 90%)
  - [x] Both backends build (--features rustls-tls if connection/streaming code changed)
  - [x] Docs / README updated if public API changed